### PR TITLE
Add /api/federal, /api alias, and /api/combined with robust PROV_TERR mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,11 @@ A comprehensive API service for finding Canadian electoral district (riding) inf
 
 The API provides lookup endpoints for different levels of government:
 
-- `GET /api` — Federal ridings (2024 boundaries)
+- `GET /api/federal` — Federal ridings (2024 boundaries)
+- `GET /api` — Alias of `/api/federal` for backwards compatibility
 - `GET /api/qc` — Quebec provincial ridings (2025 boundaries)  
 - `GET /api/on` — Ontario provincial ridings (2022 boundaries)
+- `GET /api/combined` — Federal result plus matching Ontario or Quebec provincial data in `province_data` when `PROV_TERR` indicates ON or QC (abbreviations and full names supported)
 
 ### Query Parameters
 

--- a/src/batch.ts
+++ b/src/batch.ts
@@ -2,7 +2,9 @@ import { Env, BatchLookupRequest, BatchLookupResponse, BatchJob } from './types'
 import { geocodeBatch, normalizeAddressWithGoogle, type GeocodeBatchResult } from './geocoding';
 import { incrementMetric, recordTiming } from './metrics';
 import { generateLookupCacheKey, getCachedLookupResult, setCachedLookupResult } from './cache';
-import { pickDataset } from './utils';
+import { pickDataset, provincePathFromFederalProperties } from './utils';
+
+const FEDERAL_PATH = '/api/federal';
 
 // Default batch size
 const DEFAULT_BATCH_SIZE = 10;
@@ -126,10 +128,98 @@ export async function processBatchLookupWithBatchGeocoding(
       return v ?? undefined;
     };
 
+    const runCombined = async (
+      batchReq: BatchLookupRequest,
+      lon: number,
+      lat: number
+    ): Promise<Pick<BatchLookupResponse, 'point' | 'properties' | 'riding' | 'province_data' | 'normalizedAddress' | 'addressComponents'>> => {
+      const cacheQueryFed = { ...batchReq.query, lon, lat };
+      const federalCacheKey = generateLookupCacheKey(cacheQueryFed, FEDERAL_PATH);
+      const federalCached = await getCachedLookupResult(env, federalCacheKey);
+      let normalizedAddress: string | undefined = federalCached?.normalizedAddress;
+      let addressComponents = federalCached?.addressComponents;
+      if (hasGoogleKey()) {
+        const googleResult = await resolveNormalized(lat, lon);
+        if (googleResult) {
+          normalizedAddress = googleResult.formattedAddress;
+          addressComponents = googleResult.components;
+        }
+      }
+
+      let properties: Record<string, unknown> | null;
+      let riding: string | undefined;
+      if (federalCached) {
+        properties = federalCached.properties as Record<string, unknown> | null;
+        riding = federalCached.riding;
+      } else {
+        const fed = await lookupRiding(env, FEDERAL_PATH, lon, lat);
+        properties = fed.properties as Record<string, unknown> | null;
+        riding = fed.riding;
+        const { r2Key } = pickDataset(FEDERAL_PATH);
+        const dataset = r2Key.replace('.geojson', '');
+        const toCache = {
+          properties: fed.properties,
+          riding: fed.riding,
+          ...(normalizedAddress && { normalizedAddress }),
+          ...(addressComponents && { addressComponents }),
+        };
+        await setCachedLookupResult(env, federalCacheKey, toCache, dataset, { lon, lat });
+      }
+
+      const provincePath = provincePathFromFederalProperties(properties);
+      let province_data: { riding: string; properties: Record<string, unknown>; dataset: string } | null = null;
+      if (provincePath) {
+        const provinceCacheKey = generateLookupCacheKey(cacheQueryFed, provincePath);
+        const cachedProv = await getCachedLookupResult(env, provinceCacheKey);
+        if (cachedProv) {
+          province_data = {
+            riding: cachedProv.riding ?? '',
+            properties: (cachedProv.properties || {}) as Record<string, unknown>,
+            dataset: pickDataset(provincePath).r2Key.replace('.geojson', ''),
+          };
+        } else {
+          try {
+            const provLookup = await lookupRiding(env, provincePath, lon, lat);
+            const { r2Key } = pickDataset(provincePath);
+            const dataset = r2Key.replace('.geojson', '');
+            const toCache = { properties: provLookup.properties, riding: provLookup.riding };
+            await setCachedLookupResult(env, provinceCacheKey, toCache, dataset, { lon, lat });
+            province_data = {
+              riding: provLookup.riding ?? '',
+              properties: (provLookup.properties || {}) as Record<string, unknown>,
+              dataset,
+            };
+          } catch {
+            province_data = null;
+          }
+        }
+      }
+
+      return {
+        point: { lon, lat },
+        properties,
+        riding,
+        province_data,
+        ...(normalizedAddress && { normalizedAddress }),
+        ...(addressComponents && { addressComponents }),
+      };
+    };
+
     // Process coordinates-provided requests immediately
     for (const { request, index, lon, lat } of coordinatesProvided) {
       const startTime = Date.now();
       try {
+        if (request.pathname === '/api/combined') {
+          const payload = await runCombined(request, lon, lat);
+          results[index] = {
+            id: request.id,
+            query: request.query,
+            ...payload,
+            processingTime: Date.now() - startTime,
+          };
+          continue;
+        }
+
         const cacheKey = generateLookupCacheKey({ ...request.query, lon, lat }, request.pathname);
         const cachedResult = await getCachedLookupResult(env, cacheKey);
         let normalizedAddress: string | undefined = cachedResult?.normalizedAddress;
@@ -206,6 +296,21 @@ export async function processBatchLookupWithBatchGeocoding(
         
         if (geocodingResult.success) {
           try {
+            if (request.pathname === '/api/combined') {
+              const payload = await runCombined(
+                request,
+                geocodingResult.lon,
+                geocodingResult.lat
+              );
+              results[index] = {
+                id: request.id,
+                query: request.query,
+                ...payload,
+                processingTime: Date.now() - startTime,
+              };
+              continue;
+            }
+
             const cacheKey = generateLookupCacheKey(
               { ...request.query, lon: geocodingResult.lon, lat: geocodingResult.lat },
               request.pathname

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -194,7 +194,7 @@ export async function warmCacheForLocation(
   try {
     // Warm all three datasets for this location
     const datasets = [
-      { pathname: "/api", r2Key: "federalridings-2024.geojson" },
+      { pathname: "/api/federal", r2Key: "federalridings-2024.geojson" },
       { pathname: "/api/qc", r2Key: "quebecridings-2025.geojson" },
       { pathname: "/api/on", r2Key: "ontarioridings-2022.geojson" }
     ];
@@ -243,7 +243,7 @@ export async function warmCacheForPostalCode(
     
     // Also warm lookup cache by postal code directly
     const datasets = [
-      { pathname: "/api", r2Key: "federalridings-2024.geojson" },
+      { pathname: "/api/federal", r2Key: "federalridings-2024.geojson" },
       { pathname: "/api/qc", r2Key: "quebecridings-2025.geojson" },
       { pathname: "/api/on", r2Key: "ontarioridings-2022.geojson" }
     ];

--- a/src/docs.ts
+++ b/src/docs.ts
@@ -563,15 +563,33 @@ print(data)</code></pre>
                 <div class="endpoint-header">
                     <span class="method">GET</span>
                     <span class="url">/api</span>
-                    <span class="description">Federal Riding Lookup</span>
+                    <span class="description">Federal Riding Lookup (alias)</span>
                 </div>
-                <p>Find the federal riding for any location in Canada. Supports postal codes, addresses, and coordinates. Returns riding information including FED_NUM, FED_NAME, and PROV_TERR.</p>
+                <p>Alias of <code>/api/federal</code>. Find the federal riding for any location in Canada. Supports postal codes, addresses, and coordinates. Returns riding information including FED_NUM, FED_NAME, and PROV_TERR.</p>
                 <div class="param-list">
                     <div class="param"><strong>postal</strong> - Canadian postal code (e.g., "K1A 0A6")</div>
                     <div class="param"><strong>address</strong> - Full address to geocode</div>
                     <div class="param"><strong>lat/lon</strong> - Latitude and longitude coordinates</div>
                     <div class="param"><strong>city/state/country</strong> - Location components</div>
                 </div>
+            </div>
+
+            <div class="endpoint-section">
+                <div class="endpoint-header">
+                    <span class="method">GET</span>
+                    <span class="url">/api/federal</span>
+                    <span class="description">Federal Riding Lookup</span>
+                </div>
+                <p>Canonical federal riding lookup (2024 boundaries). Same behavior as <code>/api</code>.</p>
+            </div>
+
+            <div class="endpoint-section">
+                <div class="endpoint-header">
+                    <span class="method">GET</span>
+                    <span class="url">/api/combined</span>
+                    <span class="description">Federal + Ontario or Quebec Provincial</span>
+                </div>
+                <p>Returns federal riding data plus <code>province_data</code> when the federal feature’s PROV_TERR is Ontario or Quebec (supports abbreviations and full names).</p>
             </div>
 
             <div class="endpoint-section">
@@ -809,7 +827,8 @@ print(data)</code></pre>
         <div class="section">
             <h2>Datasets</h2>
             <ul class="datasets">
-                <li><strong>/api</strong> — Federal ridings (338 ridings)</li>
+                <li><strong>/api/federal</strong> (alias <strong>/api</strong>) — Federal ridings (338 ridings)</li>
+                <li><strong>/api/combined</strong> — Federal plus matching ON/QC provincial result</li>
                 <li><strong>/api/qc</strong> — Quebec provincial ridings (125 ridings)</li>
                 <li><strong>/api/on</strong> — Ontario provincial ridings (124 ridings)</li>
             </ul>
@@ -1081,6 +1100,147 @@ export function createOpenAPISpec(baseUrl: string) {
     paths: {
       "/api": {
         get: {
+          summary: "Lookup federal riding by location (alias)",
+          description:
+            "Alias of /api/federal. Find the federal riding for a given location using postal code, address, or coordinates",
+          tags: ["Federal Ridings"],
+          parameters: [
+            {
+              name: "postal",
+              in: "query",
+              description: "Canadian postal code (e.g., K1A 0A6)",
+              required: false,
+              schema: { type: "string", example: "K1A 0A6" },
+            },
+            {
+              name: "address",
+              in: "query",
+              description: "Street address",
+              required: false,
+              schema: { type: "string", example: "123 Main St, Toronto, ON" },
+            },
+            {
+              name: "lat",
+              in: "query",
+              description: "Latitude",
+              required: false,
+              schema: { type: "number", example: 45.4215 },
+            },
+            {
+              name: "lon",
+              in: "query",
+              description: "Longitude",
+              required: false,
+              schema: { type: "number", example: -75.6972 },
+            },
+            {
+              name: "city",
+              in: "query",
+              description: "City name",
+              required: false,
+              schema: { type: "string", example: "Toronto" },
+            },
+            {
+              name: "state",
+              in: "query",
+              description: "Province or state",
+              required: false,
+              schema: { type: "string", example: "Ontario" },
+            },
+            {
+              name: "country",
+              in: "query",
+              description: "Country",
+              required: false,
+              schema: { type: "string", example: "Canada" },
+            },
+          ],
+          responses: {
+            "200": {
+              description: "Successful lookup",
+              content: {
+                "application/json": {
+                  schema: {
+                    type: "object",
+                    properties: {
+                      query: {
+                        type: "object",
+                        description: "The query parameters used",
+                      },
+                      point: {
+                        type: "object",
+                        properties: {
+                          lon: { type: "number" },
+                          lat: { type: "number" },
+                        },
+                        description: "Geocoded coordinates",
+                      },
+                      properties: {
+                        type: "object",
+                        description:
+                          "Riding properties including FED_NUM, FED_NAME, etc.",
+                        nullable: true,
+                      },
+                    },
+                  },
+                  example: {
+                    query: { postal: "K1A 0A6" },
+                    point: { lon: -75.6972, lat: 45.4215 },
+                    properties: {
+                      FED_NUM: "35047",
+                      FED_NAME: "Ottawa Centre",
+                      PROV_TERR: "Ontario",
+                    },
+                  },
+                },
+              },
+            },
+            "400": {
+              description: "Bad request - invalid parameters",
+              content: {
+                "application/json": {
+                  schema: {
+                    type: "object",
+                    properties: {
+                      error: { type: "string" },
+                    },
+                  },
+                },
+              },
+            },
+            "401": {
+              description: "Unauthorized - missing or invalid authentication",
+              content: {
+                "application/json": {
+                  schema: {
+                    type: "object",
+                    properties: {
+                      error: { type: "string" },
+                    },
+                  },
+                },
+              },
+            },
+            "429": {
+              description: "Rate limit exceeded",
+              content: {
+                "application/json": {
+                  schema: {
+                    type: "object",
+                    properties: {
+                      error: { type: "string" },
+                      retryAfter: { type: "number" },
+                    },
+                  },
+                },
+              },
+            },
+          },
+          security: [{ basicAuth: [] }, { apiKey: [] }],
+        },
+      },
+      "/api/federal": {
+        get: {
           summary: "Lookup federal riding by location",
           description:
             "Find the federal riding for a given location using postal code, address, or coordinates",
@@ -1171,6 +1331,155 @@ export function createOpenAPISpec(baseUrl: string) {
                       FED_NUM: "35047",
                       FED_NAME: "Ottawa Centre",
                       PROV_TERR: "Ontario",
+                    },
+                  },
+                },
+              },
+            },
+            "400": {
+              description: "Bad request - invalid parameters",
+              content: {
+                "application/json": {
+                  schema: {
+                    type: "object",
+                    properties: {
+                      error: { type: "string" },
+                    },
+                  },
+                },
+              },
+            },
+            "401": {
+              description: "Unauthorized - missing or invalid authentication",
+              content: {
+                "application/json": {
+                  schema: {
+                    type: "object",
+                    properties: {
+                      error: { type: "string" },
+                    },
+                  },
+                },
+              },
+            },
+            "429": {
+              description: "Rate limit exceeded",
+              content: {
+                "application/json": {
+                  schema: {
+                    type: "object",
+                    properties: {
+                      error: { type: "string" },
+                      retryAfter: { type: "number" },
+                    },
+                  },
+                },
+              },
+            },
+          },
+          security: [{ basicAuth: [] }, { apiKey: [] }],
+        },
+      },
+      "/api/combined": {
+        get: {
+          summary: "Lookup federal and provincial ridings in one call",
+          description:
+            "Returns the federal result plus the matching provincial result (Ontario or Quebec) in `province_data` when PROV_TERR maps to those provinces.",
+          tags: ["Combined Lookup"],
+          parameters: [
+            {
+              name: "postal",
+              in: "query",
+              description: "Canadian postal code (e.g., K1A 0A6)",
+              required: false,
+              schema: { type: "string", example: "K1A 0A6" },
+            },
+            {
+              name: "address",
+              in: "query",
+              description: "Street address",
+              required: false,
+              schema: { type: "string", example: "123 Main St, Toronto, ON" },
+            },
+            {
+              name: "lat",
+              in: "query",
+              description: "Latitude",
+              required: false,
+              schema: { type: "number", example: 45.4215 },
+            },
+            {
+              name: "lon",
+              in: "query",
+              description: "Longitude",
+              required: false,
+              schema: { type: "number", example: -75.6972 },
+            },
+            {
+              name: "city",
+              in: "query",
+              description: "City name",
+              required: false,
+              schema: { type: "string", example: "Toronto" },
+            },
+            {
+              name: "state",
+              in: "query",
+              description: "Province or state",
+              required: false,
+              schema: { type: "string", example: "Ontario" },
+            },
+            {
+              name: "country",
+              in: "query",
+              description: "Country",
+              required: false,
+              schema: { type: "string", example: "Canada" },
+            },
+          ],
+          responses: {
+            "200": {
+              description: "Successful lookup (federal + optional provincial)",
+              content: {
+                "application/json": {
+                  schema: {
+                    type: "object",
+                    properties: {
+                      query: { type: "object" },
+                      point: {
+                        type: "object",
+                        properties: {
+                          lon: { type: "number" },
+                          lat: { type: "number" },
+                        },
+                      },
+                      riding: { type: "string" },
+                      properties: { type: "object", nullable: true },
+                      province_data: {
+                        type: "object",
+                        nullable: true,
+                        properties: {
+                          riding: { type: "string" },
+                          properties: { type: "object" },
+                          dataset: {
+                            type: "string",
+                            enum: ["ontarioridings-2022", "quebecridings-2025"],
+                          },
+                        },
+                      },
+                      normalizedAddress: { type: "string" },
+                      addressComponents: { type: "object" },
+                    },
+                  },
+                  example: {
+                    query: { address: "123 Main St, Toronto" },
+                    point: { lon: -79.3832, lat: 43.6532 },
+                    riding: "Toronto Centre",
+                    properties: { FED_NUM: "35075", PROV_TERR: "Ontario" },
+                    province_data: {
+                      riding: "Toronto Centre",
+                      properties: { PR_NUM: "082" },
+                      dataset: "ontarioridings-2022",
                     },
                   },
                 },
@@ -1372,7 +1681,7 @@ export function createOpenAPISpec(baseUrl: string) {
                           id: { type: "string" },
                           pathname: {
                             type: "string",
-                            enum: ["/api", "/api/qc", "/api/on"],
+                            enum: ["/api", "/api/federal", "/api/combined", "/api/qc", "/api/on"],
                           },
                           query: {
                             type: "object",
@@ -1448,7 +1757,7 @@ export function createOpenAPISpec(baseUrl: string) {
                           id: { type: "string" },
                           pathname: {
                             type: "string",
-                            enum: ["/api", "/api/qc", "/api/on"],
+                            enum: ["/api", "/api/federal", "/api/combined", "/api/qc", "/api/on"],
                           },
                           query: {
                             type: "object",
@@ -2409,6 +2718,10 @@ export function createOpenAPISpec(baseUrl: string) {
       {
         name: "Federal Ridings",
         description: "Operations for federal riding lookups",
+      },
+      {
+        name: "Combined Lookup",
+        description: "Federal plus Ontario or Quebec provincial riding in one request",
       },
       {
         name: "Quebec Ridings",

--- a/src/types.ts
+++ b/src/types.ts
@@ -214,6 +214,8 @@ export interface BatchLookupResponse {
   query: QueryParams;
   point?: { lon: number; lat: number };
   properties: Record<string, unknown> | null;
+  riding?: string;
+  province_data?: { riding: string; properties: Record<string, unknown>; dataset: string } | null;
   normalizedAddress?: string;
   addressComponents?: GoogleAddressComponents;
   error?: string;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -437,10 +437,37 @@ export function getCorrelationId(request: Request): string {
 // Dataset selection
 export function pickDataset(pathname: string): { r2Key: string } {
   // Map routes to R2 object keys
+  if (pathname === "/api/federal" || pathname === "/api") return { r2Key: "federalridings-2024.geojson" };
   if (pathname === "/api/qc") return { r2Key: "quebecridings-2025.geojson" };
   if (pathname === "/api/on") return { r2Key: "ontarioridings-2022.geojson" };
-  // default federal
+  // default federal (unknown /api/* path)
   return { r2Key: "federalridings-2024.geojson" };
+}
+
+const PROV_TERR_TO_PROVINCE_PATH: Record<string, "/api/on" | "/api/qc"> = {
+  ON: "/api/on",
+  ONT: "/api/on",
+  ONTARIO: "/api/on",
+  QC: "/api/qc",
+  QUE: "/api/qc",
+  QUEBEC: "/api/qc",
+};
+
+/**
+ * Maps federal feature PROV_TERR (abbreviation or full name, EN/FR) to a provincial lookup path.
+ */
+export function provincePathFromFederalProperties(
+  properties: Record<string, unknown> | null | undefined
+): "/api/on" | "/api/qc" | null {
+  if (!properties) return null;
+  const raw = properties.PROV_TERR;
+  if (typeof raw !== "string" || !raw.trim()) return null;
+  const key = raw
+    .trim()
+    .toUpperCase()
+    .normalize("NFD")
+    .replace(/\p{M}/gu, "");
+  return PROV_TERR_TO_PROVINCE_PATH[key] ?? null;
 }
 
 // Query parsing

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -23,7 +23,8 @@ import {
   isPointInPolygon, 
   withTimeout, 
   withRetry, 
-  pickDataset, 
+  pickDataset,
+  provincePathFromFederalProperties,
   parseQuery, 
   checkBasicAuth, 
   badRequest, 
@@ -72,6 +73,13 @@ import { getTimeoutConfig, getRetryConfig, TIME_CONSTANTS } from './config';
 
 // Global state
 let cacheWarmingInitialized = false;
+
+const FEDERAL_PATH = "/api/federal";
+
+function normalizeLookupPathname(pathname: string): string {
+  if (pathname === "/api") return FEDERAL_PATH;
+  return pathname;
+}
 
 /**
  * Handle scheduled events (Cron Triggers) for cache warming.
@@ -582,7 +590,7 @@ export default {
           }
           
           try {
-            const result = await lookupRiding(env, `/api`, lon, lat);
+            const result = await lookupRiding(env, FEDERAL_PATH, lon, lat);
             return new Response(JSON.stringify(result), {
               headers: { 
                 "content-type": "application/json; charset=UTF-8",
@@ -823,7 +831,7 @@ export default {
             const requests = body.requests.map((req, index) => ({
               id: req.id || `req_${index}`,
               query: req.query,
-              pathname: req.pathname || '/api'
+              pathname: normalizeLookupPathname(req.pathname || '/api')
             }));
             
             const cb = geocodingCircuitBreaker ? { execute: (k: string, fn: () => Promise<any>) => geocodingCircuitBreaker!.execute(k, fn) } : undefined;
@@ -1035,6 +1043,8 @@ export default {
       
       // Main lookup endpoint
       if (pathname.startsWith('/api')) {
+        const lookupPathname = normalizeLookupPathname(pathname);
+
         // Check rate limiting
         const clientId = getClientId(request);
         if (!checkRateLimit(env, clientId)) {
@@ -1056,19 +1066,149 @@ export default {
           
           // Use sanitized query parameters
           const sanitizedQuery = validation.sanitized!;
+          const origin = request.headers.get('Origin');
           
           // Increment lookup requests metric (before cache check)
           incrementMetric('lookupRequests');
-          
-          // Generate cache key
-          const cacheKey = generateLookupCacheKey(sanitizedQuery, pathname);
+
+          const timeoutConfig = getTimeoutConfig(env);
+          const cb = geocodingCircuitBreaker ? { execute: (k: string, fn: () => Promise<any>) => geocodingCircuitBreaker!.execute(k, fn) } : undefined;
+
+          // Combined endpoint: federal + optional ON/QC provincial lookup
+          if (lookupPathname === '/api/combined') {
+            const federalPath = FEDERAL_PATH;
+            const federalCacheKey = generateLookupCacheKey(sanitizedQuery, federalPath);
+            const federalCached = await getCachedLookupResult(env, federalCacheKey);
+            if (federalCached) {
+              incrementMetric('lookupCacheHits');
+            }
+
+            let point = federalCached?.point || (sanitizedQuery.lat !== undefined && sanitizedQuery.lon !== undefined
+              ? { lon: sanitizedQuery.lon, lat: sanitizedQuery.lat }
+              : undefined);
+
+            let normalizedAddress: string | undefined;
+            let addressComponents: LookupResult['addressComponents'];
+
+            if (!point) {
+              const geocodeResult = await withTimeout(
+                geocodeIfNeeded(env, sanitizedQuery, request, undefined, cb),
+                timeoutConfig.geocoding,
+                "Geocoding"
+              );
+              point = { lon: geocodeResult.lon, lat: geocodeResult.lat };
+              normalizedAddress = geocodeResult.normalizedAddress;
+              addressComponents = geocodeResult.addressComponents;
+              if (request?.headers.get('X-Google-API-Key') || env.GOOGLE_MAPS_KEY) {
+                const googleResult = await normalizeAddressWithGoogle(env, geocodeResult.lat, geocodeResult.lon, request, cb);
+                if (googleResult) {
+                  normalizedAddress = googleResult.formattedAddress;
+                  addressComponents = googleResult.components;
+                }
+              }
+            }
+
+            const { lon, lat } = point;
+
+            let federalResult: LookupResult;
+            if (federalCached) {
+              federalResult = {
+                properties: federalCached.properties || {},
+                riding: federalCached.riding,
+                ...(federalCached.normalizedAddress && { normalizedAddress: federalCached.normalizedAddress }),
+                ...(federalCached.addressComponents && { addressComponents: federalCached.addressComponents })
+              };
+            } else {
+              incrementMetric('lookupCacheMisses');
+              const fedLookup = await withTimeout(
+                lookupRiding(env, federalPath, lon, lat),
+                timeoutConfig.lookup,
+                "Riding lookup"
+              );
+              federalResult = { properties: fedLookup.properties, riding: fedLookup.riding };
+              if (normalizedAddress) federalResult.normalizedAddress = normalizedAddress;
+              if (addressComponents) federalResult.addressComponents = addressComponents;
+              const { r2Key } = pickDataset(federalPath);
+              const dataset = r2Key.replace('.geojson', '');
+              await setCachedLookupResult(env, federalCacheKey, federalResult, dataset, { lon, lat });
+            }
+
+            const provincePath = provincePathFromFederalProperties(federalResult.properties as Record<string, unknown> | null);
+
+            let provinceData: { riding: string; properties: Record<string, unknown>; dataset: string } | null = null;
+            let provinceCachedHit = false;
+
+            if (provincePath) {
+              const provinceCacheKey = generateLookupCacheKey(sanitizedQuery, provincePath);
+              const cachedProv = await getCachedLookupResult(env, provinceCacheKey);
+              if (cachedProv) {
+                incrementMetric('lookupCacheHits');
+                provinceCachedHit = true;
+                provinceData = {
+                  riding: cachedProv.riding ?? '',
+                  properties: (cachedProv.properties || {}) as Record<string, unknown>,
+                  dataset: pickDataset(provincePath).r2Key.replace('.geojson', '')
+                };
+              } else {
+                incrementMetric('lookupCacheMisses');
+                try {
+                  const provLookup = await withTimeout(
+                    lookupRiding(env, provincePath, lon, lat),
+                    timeoutConfig.lookup,
+                    "Riding lookup (province)"
+                  );
+                  const { r2Key } = pickDataset(provincePath);
+                  const dataset = r2Key.replace('.geojson', '');
+                  const lookupResult: LookupResult = { properties: provLookup.properties, riding: provLookup.riding };
+                  await setCachedLookupResult(env, provinceCacheKey, lookupResult, dataset, { lon, lat });
+                  provinceData = {
+                    riding: lookupResult.riding ?? '',
+                    properties: (lookupResult.properties || {}) as Record<string, unknown>,
+                    dataset
+                  };
+                } catch (provError) {
+                  console.warn(`[${correlationId}] Provincial lookup failed (${provincePath}):`, provError instanceof Error ? provError.message : provError);
+                  provinceData = null;
+                }
+              }
+            }
+
+            recordTiming('totalLookupTime', Date.now() - startTime);
+
+            let cacheStatus: 'HIT' | 'MISS' | 'PARTIAL' = 'MISS';
+            const federalHit = !!federalCached;
+            const provinceHit = provinceCachedHit;
+            if (federalHit && (provincePath ? provinceHit : true)) {
+              cacheStatus = 'HIT';
+            } else if (federalHit || provinceHit) {
+              cacheStatus = 'PARTIAL';
+            }
+
+            return new Response(JSON.stringify({
+              query: sanitizedQuery,
+              point: { lon, lat },
+              riding: federalResult.riding,
+              properties: federalResult.properties,
+              province_data: provinceData,
+              ...(federalResult.normalizedAddress && { normalizedAddress: federalResult.normalizedAddress }),
+              ...(federalResult.addressComponents && { addressComponents: federalResult.addressComponents }),
+              correlationId
+            }), {
+              headers: {
+                "content-type": "application/json; charset=UTF-8",
+                "X-Cache-Status": cacheStatus,
+                ...getCorsHeaders(origin)
+              }
+            });
+          }
+
+          const cacheKey = generateLookupCacheKey(sanitizedQuery, lookupPathname);
           
           // Check lookup cache
           const cachedResult = await getCachedLookupResult(env, cacheKey);
           if (cachedResult) {
             incrementMetric('lookupCacheHits');
             recordTiming('totalLookupTime', Date.now() - startTime);
-            const origin = request.headers.get('Origin');
             // Use point from cache entry if available, otherwise fall back to sanitizedQuery
             const point = cachedResult.point || (sanitizedQuery.lat !== undefined && sanitizedQuery.lon !== undefined 
               ? { lon: sanitizedQuery.lon, lat: sanitizedQuery.lat } 
@@ -1092,8 +1232,6 @@ export default {
           
           incrementMetric('lookupCacheMisses');
           
-          const timeoutConfig = getTimeoutConfig(env);
-          const cb = geocodingCircuitBreaker ? { execute: (k: string, fn: () => Promise<any>) => geocodingCircuitBreaker!.execute(k, fn) } : undefined;
           const geocodeResult = await withTimeout(
             geocodeIfNeeded(env, sanitizedQuery, request, undefined, cb),
             timeoutConfig.geocoding,
@@ -1113,12 +1251,12 @@ export default {
           }
           
           const result = await withTimeout(
-            lookupRiding(env, pathname, lon, lat),
+            lookupRiding(env, lookupPathname, lon, lat),
             timeoutConfig.lookup,
             "Riding lookup"
           );
           
-          const { r2Key } = pickDataset(pathname);
+          const { r2Key } = pickDataset(lookupPathname);
           const dataset = r2Key.replace('.geojson', '');
           const lookupResult: LookupResult = {
             properties: result.properties,
@@ -1129,7 +1267,6 @@ export default {
           await setCachedLookupResult(env, cacheKey, lookupResult, dataset, { lon, lat });
           
           recordTiming('totalLookupTime', Date.now() - startTime);
-          const origin = request.headers.get('Origin');
           return new Response(JSON.stringify({
             query: sanitizedQuery,
             point: { lon, lat },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements the behavior discussed for [PR #6](https://github.com/chester-hill-solutions/riding-and-address/pull/6) and fixes the issues found in review.

## Changes

- **`GET /api/federal`** — Canonical federal lookup; **`GET /api`** remains an alias (normalized internally so cache keys and `pickDataset` align with `/api/federal`).
- **`GET /api/combined`** — Returns federal `riding` / `properties` plus optional **`province_data`** when federal `PROV_TERR` maps to Ontario or Quebec. Mapping uses **`provincePathFromFederalProperties`** in `utils.ts`: supports `ON` / `QC`, full names (`Ontario`, `Quebec`, `QUÉBEC` with accents normalized), and short forms `ONT` / `QUE`.
- **Combined response parity** — When geocoding runs (no federal cache hit), the same Google reverse-geocode normalization path as single lookups can populate `normalizedAddress` / `addressComponents` on the combined response when a key is available.
- **Batch** — `pathname: "/api/combined"` is handled in `processBatchLookupWithBatchGeocoding` with the same federal + provincial cache strategy.
- **Cache warming** — Federal warm path uses `/api/federal` for consistent keys.
- **Docs** — README, landing page, OpenAPI (`/api`, `/api/federal`, `/api/combined`), batch/queue pathname enums.

## Verification

- `npm install` and `npx wrangler deploy --dry-run` succeed locally.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2225e544-d838-4a15-8ac1-8667f37099cc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2225e544-d838-4a15-8ac1-8667f37099cc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

