### PR TITLE
feat: add benchmark script and enhance API documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The API provides lookup endpoints for different levels of government:
 - `GET /api` — Alias of `/api/federal` for backwards compatibility
 - `GET /api/qc` — Quebec provincial ridings (2025 boundaries)  
 - `GET /api/on` — Ontario provincial ridings (2022 boundaries)
-- `GET /api/combined` — Federal result plus matching Ontario or Quebec provincial data in `province_data` when `PROV_TERR` indicates ON or QC (abbreviations and full names supported)
+- `GET /api/combined` — Convenience endpoint equivalent to federal lookup with `include_province=true` by default
 
 ### Query Parameters
 
@@ -21,21 +21,55 @@ Provide either coordinates or a geocodable address:
 - `city` — City name (optional, helps with geocoding)
 - `state` or `province` — Province/state (optional)
 - `country` — Country (optional, defaults to Canada)
+- `include_province` — Optional boolean (`true`/`false`) to include matching Ontario or Quebec provincial data in `province_data`
+- `return` — Optional comma-separated list of extra response fields (see below)
+
+#### Optional `include_province` flag
+
+Request provincial riding data without changing the base federal lookup:
+
+- `include_province=true` — include `province_data` when the federal result's `PROV_TERR` maps to ON or QC
+- `include_province=false` — omit provincial lookup (even on `/api/combined`)
+- `/api/combined` defaults to `include_province=true` when the flag is omitted
+
+#### Optional `return` selector
+
+Request additional response metadata:
+
+| Token | Description |
+|-------|-------------|
+| `municipality` | Include `properties.MUNICIPALITY` when resolvable from ODA/Google address normalization |
+
+Examples:
+
+- `return=municipality`
+- `include_province=true&return=municipality`
+
+Rules:
+
+- Unknown `return` tokens return `400 INVALID_QUERY`.
+- Invalid `include_province` values return `400 INVALID_QUERY`.
 
 #### Examples:
 - `GET /api?lat=45.5017&lon=-73.5673`
+- `GET /api?include_province=true&postal=M5V2T6`
+- `GET /api?include_province=true&return=municipality&address=123%20Main%20St&city=Toronto&province=ON`
 - `GET /api/qc?address=350%20Rue%20St-Paul%20E,%20Montréal`
-- `GET /api/on?postal=M5V2T6`
-- `GET /api?address=123%20Main%20St&city=Toronto&province=ON`
+- `GET /api/on?postal=M5V2T6&return=municipality`
+- `GET /api/combined?address=757%20Victoria%20Park&city=Toronto&province=ON`
 
 #### Response Format:
 ```json
 {
   "query": { "lat": 45.5017, "lon": -73.5673 },
   "point": { "lon": -73.5673, "lat": 45.5017 },
-  "properties": { /* riding properties from GeoJSON feature, or null */ }
+  "properties": { /* riding properties from GeoJSON feature, or null */ },
+  "province_data": null,
+  "municipality": "TORONTO"
 }
 ```
+
+`province_data` is included only when `include_province=true` (or by default on `/api/combined`). Top-level `municipality` and `properties.MUNICIPALITY` are included only when `return=municipality`.
 
 ### ODA Self-Hosted Geocoding
 

--- a/docs/hosting.md
+++ b/docs/hosting.md
@@ -1,0 +1,43 @@
+# Hosting Decision: Cloudflare Workers vs CHS GCP
+
+## Current target
+
+This service is implemented as a **Cloudflare Worker** with platform-native bindings:
+
+- **R2** — GeoJSON riding boundary storage
+- **KV** — geocoding and lookup result cache
+- **D1** — ODA address database and optional spatial riding index
+- **Durable Objects** — queue management and circuit breakers
+- **Cron Triggers** — cache warming and webhook processing
+
+The production deployment path is `wrangler deploy` using [`wrangler.jsonc`](../wrangler.jsonc).
+
+## Why Cloudflare remains the implementation target
+
+1. **Architecture fit** — spatial lookup, edge caching, and geocoding cache are already wired to Cloudflare primitives.
+2. **Latency profile** — issue `#8` performance work targets warm edge lookups; Workers + KV cache align with that goal.
+3. **Operational cost** — no separate compute layer to manage for the lookup API itself.
+
+## If CHS GCP hosting is required
+
+Treat GCP migration as a **separate project**, not a feature tweak. A migration would need replacements for:
+
+| Cloudflare component | GCP equivalent (examples) |
+|---------------------|---------------------------|
+| Workers runtime | Cloud Run or GKE service |
+| R2 ridings bucket | Cloud Storage |
+| KV caches | Memorystore (Redis) or Firestore |
+| D1 ODA / spatial DB | Cloud SQL (Postgres) or AlloyDB |
+| Durable Objects | Cloud Tasks + Redis/Pub/Sub coordination |
+| Cron Triggers | Cloud Scheduler |
+| Wrangler secrets | Secret Manager |
+
+Recommended approach:
+
+1. Keep this repository on Cloudflare until parity tests and benchmarks are green.
+2. Open a dedicated migration issue with infrastructure diagrams and cutover plan.
+3. Extract lookup logic (`lookup-expansion`, `spatial`, `geocoding`) into runtime-agnostic modules before porting handlers.
+
+## Issue `#5` resolution
+
+Unless product explicitly requires GCP now, close `#5` as **deferred** with this document as the decision record and track GCP migration separately if needed.

--- a/docs/oda-fixtures.md
+++ b/docs/oda-fixtures.md
@@ -92,3 +92,24 @@ Fixture CSV: `test/fixtures/oda/fixture.csv`
 - Federal riding in `properties`
 - Ontario provincial riding in `province_data` when applicable
 - Optional `geocodeMethod`, `mailingAddress` in response
+
+## Case 11: Optional `return` selector with municipality
+
+**Query:** `GET /api?return=municipality&address=123%20Main%20St&city=Toronto&province=ON`
+
+**Expected:**
+- Federal riding in `properties`
+- `properties.MUNICIPALITY` set from ODA `mailingAddress.municipality` (e.g. `TORONTO`)
+- Top-level `municipality` matches `properties.MUNICIPALITY`
+- No `province_data` unless `include_province=true` is also requested
+
+## Case 12: OpenNorth parity — 757 Victoria Park
+
+**Query:** `GET /api?include_province=true&address=757%20Victoria%20Park&city=Toronto&province=ON`
+
+**Context:** OpenNorth reports Beaches-East York from postcode for this address; this service expects the provincial riding **Scarborough Southwest (SSW)** for the resolved point.
+
+**Expected:**
+- Federal riding resolved for the geocoded point
+- `province_data.riding` or provincial properties indicate Scarborough Southwest (not Beaches-East York)
+- Document resolved coordinates in tests if live geocoding varies

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "lint:fix": "eslint src/**/*.ts test/**/*.ts --fix",
     "test": "vitest run",
     "test:watch": "vitest",
+    "benchmark:lookup": "tsx scripts/benchmark-lookup.ts",
     "import:oda": "tsx scripts/import-oda.ts"
   },
   "keywords": [],

--- a/scripts/benchmark-lookup.ts
+++ b/scripts/benchmark-lookup.ts
@@ -1,0 +1,60 @@
+/**
+ * Lightweight lookup benchmark for issue #8.
+ * Run: npx tsx scripts/benchmark-lookup.ts
+ */
+import { createSpatialIndex, findCandidateFeatures } from '../src/spatial';
+import type { GeoJSONFeature, GeoJSONFeatureCollection } from '../src/types';
+
+function createPolygonFeature(coords: number[][][], properties: Record<string, unknown> = {}): GeoJSONFeature {
+  return {
+    type: 'Feature',
+    geometry: { type: 'Polygon', coordinates: coords },
+    properties,
+  };
+}
+
+function buildFixtureCollection(size: number): GeoJSONFeatureCollection {
+  const features: GeoJSONFeature[] = [];
+  const grid = Math.ceil(Math.sqrt(size));
+  for (let i = 0; i < size; i++) {
+    const row = Math.floor(i / grid);
+    const col = i % grid;
+    const x = col * 0.1;
+    const y = row * 0.1;
+    features.push(
+      createPolygonFeature(
+        [[[x, y], [x + 0.08, y], [x + 0.08, y + 0.08], [x, y + 0.08], [x, y]]],
+        { id: i }
+      )
+    );
+  }
+  return { type: 'FeatureCollection', features };
+}
+
+function benchmark(label: string, iterations: number, fn: () => void): number {
+  const start = performance.now();
+  for (let i = 0; i < iterations; i++) {
+    fn();
+  }
+  const elapsed = performance.now() - start;
+  const perOp = elapsed / iterations;
+  console.log(`${label}: ${perOp.toFixed(3)}ms/op (${iterations} iterations, ${elapsed.toFixed(1)}ms total)`);
+  return perOp;
+}
+
+const collection = buildFixtureCollection(500);
+const index = createSpatialIndex(collection);
+const points = [
+  { name: 'Toronto', lon: -79.3832, lat: 43.6532 },
+  { name: '757 Victoria Park fixture', lon: -79.3124, lat: 43.6891 },
+  { name: 'Montreal', lon: -73.5673, lat: 45.5017 },
+];
+
+console.log('Riding lookup spatial index benchmark');
+console.log(`Features indexed: ${collection.features.length}`);
+
+for (const point of points) {
+  benchmark(`candidate lookup @ ${point.name}`, 1000, () => {
+    findCandidateFeatures(point.lon, point.lat, index);
+  });
+}

--- a/src/batch.ts
+++ b/src/batch.ts
@@ -1,13 +1,9 @@
 import { Env, BatchLookupRequest, BatchLookupResponse, BatchJob, QueryParams, LookupResult, GoogleAddressComponents } from './types';
 import { parseBatchLookupRequests } from './validation';
-import { normalizeAddressWithGoogle, type GeocodeBatchResult } from './geocoding';
+import { type GeocodeBatchResult } from './geocoding';
 import { incrementMetric, recordTiming } from './metrics';
-import { generateLookupCacheKey, getCachedLookupResult, setCachedLookupResult } from './cache';
-import { pickDataset, provincePathFromFederalProperties } from './utils';
-import { isOdaEnabled } from './oda-config';
-import { resolveNormalizedAddress } from './oda-handlers';
-
-const FEDERAL_PATH = '/api/federal';
+import { performExpandedLookup, type NormalizedAddressContext } from './lookup-expansion';
+import { resolveIncludeProvince } from './return-selector';
 
 // Type aliases for callback functions to avoid explicit any
 type GeocodeFunction = (env: Env, query: QueryParams, request?: Request) => Promise<{ lon: number; lat: number }>;
@@ -126,91 +122,38 @@ export async function processBatchLookupWithBatchGeocoding(
       }
     }
     
-    const hasGoogleKey = () => !isOdaEnabled(env) && !!(request?.headers?.get?.('X-Google-API-Key') ?? env.GOOGLE_MAPS_KEY);
-    const resolveNormalized = async (lat: number, lon: number, query: QueryParams): Promise<{ formattedAddress?: string; components?: GoogleAddressComponents } | undefined> => {
-      if (isOdaEnabled(env)) {
-        const v = await resolveNormalizedAddress(env, lat, lon, query, request, circuitBreaker);
-        return v ? { formattedAddress: v.normalizedAddress, components: v.addressComponents } : undefined;
-      }
-      if (!hasGoogleKey()) return undefined;
-      const v = await normalizeAddressWithGoogle(env, lat, lon, request, circuitBreaker);
-      return v ?? undefined;
-    };
-
-    const runCombined = async (
+    const runExpandedLookup = async (
       batchReq: BatchLookupRequest,
       lon: number,
-      lat: number
-    ): Promise<Pick<BatchLookupResponse, 'point' | 'properties' | 'riding' | 'province_data' | 'normalizedAddress' | 'addressComponents'>> => {
-      const cacheQueryFed = { ...batchReq.query, lon, lat };
-      const federalCacheKey = generateLookupCacheKey(cacheQueryFed, FEDERAL_PATH);
-      const federalCached = await getCachedLookupResult(env, federalCacheKey);
-      let normalizedAddress: string | undefined = federalCached?.normalizedAddress;
-      let addressComponents = federalCached?.addressComponents;
-      if (hasGoogleKey() || isOdaEnabled(env)) {
-        const googleResult = await resolveNormalized(lat, lon, batchReq.query);
-        if (googleResult) {
-          normalizedAddress = googleResult.formattedAddress;
-          addressComponents = googleResult.components;
+      lat: number,
+      addressContext?: NormalizedAddressContext
+    ): Promise<Pick<BatchLookupResponse, 'point' | 'properties' | 'riding' | 'province_data' | 'municipality' | 'normalizedAddress' | 'addressComponents'>> => {
+      const returnFields = batchReq.query.returnFields ?? [];
+      const includeProvince = resolveIncludeProvince(batchReq.pathname, batchReq.query.includeProvince);
+      const expanded = await performExpandedLookup(
+        env,
+        batchReq.pathname,
+        { ...batchReq.query, lon, lat },
+        returnFields,
+        includeProvince,
+        lookupRiding,
+        {
+          lon,
+          lat,
+          request,
+          circuitBreaker,
+          addressContext,
         }
-      }
-
-      let properties: Record<string, unknown> | null;
-      let riding: string | undefined;
-      if (federalCached) {
-        properties = federalCached.properties as Record<string, unknown> | null;
-        riding = federalCached.riding;
-      } else {
-        const fed = await lookupRiding(env, FEDERAL_PATH, lon, lat);
-        properties = fed.properties as Record<string, unknown> | null;
-        riding = fed.riding;
-        const { r2Key } = pickDataset(FEDERAL_PATH);
-        const dataset = r2Key.replace('.geojson', '');
-        const toCache = {
-          properties: fed.properties,
-          riding: fed.riding,
-          ...(normalizedAddress && { normalizedAddress }),
-          ...(addressComponents && { addressComponents }),
-        };
-        await setCachedLookupResult(env, federalCacheKey, toCache, dataset, { lon, lat });
-      }
-
-      const provincePath = provincePathFromFederalProperties(properties);
-      let province_data: { riding: string; properties: Record<string, unknown>; dataset: string } | null = null;
-      if (provincePath) {
-        const provinceCacheKey = generateLookupCacheKey(cacheQueryFed, provincePath);
-        const cachedProv = await getCachedLookupResult(env, provinceCacheKey);
-        if (cachedProv) {
-          province_data = {
-            riding: cachedProv.riding ?? '',
-            properties: (cachedProv.properties || {}) as Record<string, unknown>,
-            dataset: pickDataset(provincePath).r2Key.replace('.geojson', ''),
-          };
-        } else {
-          try {
-            const provLookup = await lookupRiding(env, provincePath, lon, lat);
-            const { r2Key } = pickDataset(provincePath);
-            const dataset = r2Key.replace('.geojson', '');
-            const toCache = { properties: provLookup.properties, riding: provLookup.riding };
-            await setCachedLookupResult(env, provinceCacheKey, toCache, dataset, { lon, lat });
-            province_data = {
-              riding: provLookup.riding ?? '',
-              properties: (provLookup.properties || {}) as Record<string, unknown>,
-              dataset,
-            };
-          } catch {
-            province_data = null;
-          }
-        }
-      }
+      );
 
       return {
         point: { lon, lat },
-        properties,
-        riding,
-        province_data,
-        ...(normalizedAddress && { normalizedAddress }),
-        ...(addressComponents && { addressComponents }),
+        properties: expanded.properties,
+        riding: expanded.riding,
+        ...(expanded.province_data !== undefined && { province_data: expanded.province_data }),
+        ...(expanded.municipality && { municipality: expanded.municipality }),
+        ...(expanded.normalizedAddress && { normalizedAddress: expanded.normalizedAddress }),
+        ...(expanded.addressComponents && { addressComponents: expanded.addressComponents }),
       };
     };
 
@@ -218,69 +161,14 @@ export async function processBatchLookupWithBatchGeocoding(
     for (const { request, index, lon, lat } of coordinatesProvided) {
       const startTime = Date.now();
       try {
-        if (request.pathname === '/api/combined') {
-          const payload = await runCombined(request, lon, lat);
-          results[index] = {
-            id: request.id,
-            query: request.query,
-            ...payload,
-            processingTime: Date.now() - startTime,
-          };
-          continue;
-        }
-
-        const cacheKey = generateLookupCacheKey({ ...request.query, lon, lat }, request.pathname);
-        const cachedResult = await getCachedLookupResult(env, cacheKey);
-        let normalizedAddress: string | undefined = cachedResult?.normalizedAddress;
-        let addressComponents = cachedResult?.addressComponents;
-
-        if (cachedResult) {
-          // Always try to get normalized address via reverse geocoding when Google API key is available
-      if (hasGoogleKey() || isOdaEnabled(env)) {
-        const googleResult = await resolveNormalized(lat, lon, request.query);
-            if (googleResult) {
-              normalizedAddress = googleResult.formattedAddress;
-              addressComponents = googleResult.components;
-            }
-          }
-          const processingTime = Date.now() - startTime;
-          results[index] = {
-            id: request.id,
-            query: request.query,
-            point: { lon, lat },
-            properties: cachedResult.properties,
-            ...(normalizedAddress && { normalizedAddress }),
-            ...(addressComponents && { addressComponents }),
-            processingTime
-          };
-        } else {
-          const result = await lookupRiding(env, request.pathname, lon, lat);
-      if (hasGoogleKey() || isOdaEnabled(env)) {
-        const googleResult = await resolveNormalized(lat, lon, request.query);
-            if (googleResult) {
-              normalizedAddress = googleResult.formattedAddress;
-              addressComponents = googleResult.components;
-            }
-          }
-          const processingTime = Date.now() - startTime;
-          const { r2Key } = pickDataset(request.pathname);
-          const dataset = r2Key.replace('.geojson', '');
-          const toCache = { 
-            ...result, 
-            ...(normalizedAddress && { normalizedAddress }),
-            ...(addressComponents && { addressComponents })
-          };
-          await setCachedLookupResult(env, cacheKey, toCache, dataset, { lon, lat });
-          results[index] = {
-            id: request.id,
-            query: request.query,
-            point: { lon, lat },
-            properties: result.properties,
-            ...(normalizedAddress && { normalizedAddress }),
-            ...(addressComponents && { addressComponents }),
-            processingTime
-          };
-        }
+        const payload = await runExpandedLookup(request, lon, lat);
+        results[index] = {
+          id: request.id,
+          query: request.query,
+          ...payload,
+          processingTime: Date.now() - startTime,
+        };
+        continue;
       } catch (error) {
         const processingTime = Date.now() - startTime;
         results[index] = {
@@ -305,69 +193,22 @@ export async function processBatchLookupWithBatchGeocoding(
         
         if (geocodingResult.success) {
           try {
-            if (request.pathname === '/api/combined') {
-              const payload = await runCombined(
-                request,
-                geocodingResult.lon,
-                geocodingResult.lat
-              );
-              results[index] = {
-                id: request.id,
-                query: request.query,
-                ...payload,
-                processingTime: Date.now() - startTime,
-              };
-              continue;
-            }
-
-            const cacheKey = generateLookupCacheKey(
-              { ...request.query, lon: geocodingResult.lon, lat: geocodingResult.lat },
-              request.pathname
+            const addressContext: NormalizedAddressContext = {
+              normalizedAddress: geocodingResult.normalizedAddress,
+              addressComponents: geocodingResult.addressComponents,
+            };
+            const payload = await runExpandedLookup(
+              request,
+              geocodingResult.lon,
+              geocodingResult.lat,
+              addressContext
             );
-            const cachedResult = await getCachedLookupResult(env, cacheKey);
-            let normalizedAddress: string | undefined = geocodingResult.normalizedAddress ?? cachedResult?.normalizedAddress;
-            let addressComponents = geocodingResult.addressComponents ?? cachedResult?.addressComponents;
-            // Always try to get normalized address via reverse geocoding when Google API key is available
-            if (hasGoogleKey() || isOdaEnabled(env)) {
-              const googleResult = await resolveNormalized(geocodingResult.lat, geocodingResult.lon, request.query);
-              if (googleResult) {
-                normalizedAddress = googleResult.formattedAddress;
-                addressComponents = googleResult.components;
-              }
-            }
-            
-            if (cachedResult) {
-              const processingTime = Date.now() - startTime;
-              results[index] = {
-                id: request.id,
-                query: request.query,
-                point: { lon: geocodingResult.lon, lat: geocodingResult.lat },
-                properties: cachedResult.properties,
-                ...(normalizedAddress && { normalizedAddress }),
-                ...(addressComponents && { addressComponents }),
-                processingTime
-              };
-            } else {
-              const result = await lookupRiding(env, request.pathname, geocodingResult.lon, geocodingResult.lat);
-              const processingTime = Date.now() - startTime;
-              const { r2Key } = pickDataset(request.pathname);
-              const dataset = r2Key.replace('.geojson', '');
-              const toCache = { 
-                ...result, 
-                ...(normalizedAddress && { normalizedAddress }),
-                ...(addressComponents && { addressComponents })
-              };
-              await setCachedLookupResult(env, cacheKey, toCache, dataset, { lon: geocodingResult.lon, lat: geocodingResult.lat });
-              results[index] = {
-                id: request.id,
-                query: request.query,
-                point: { lon: geocodingResult.lon, lat: geocodingResult.lat },
-                properties: result.properties,
-                ...(normalizedAddress && { normalizedAddress }),
-                ...(addressComponents && { addressComponents }),
-                processingTime
-              };
-            }
+            results[index] = {
+              id: request.id,
+              query: request.query,
+              ...payload,
+              processingTime: Date.now() - startTime,
+            };
           } catch (error) {
             const processingTime = Date.now() - startTime;
             results[index] = {

--- a/src/batch.ts
+++ b/src/batch.ts
@@ -1,14 +1,22 @@
-import { Env, BatchLookupRequest, BatchLookupResponse, BatchJob, QueryParams, LookupResult, GoogleAddressComponents } from './types';
+import {
+  Env,
+  BatchLookupRequest,
+  BatchLookupResponse,
+  BatchJob,
+  QueryParams,
+  LookupResult,
+  GoogleAddressComponents,
+  CircuitBreakerExecutor,
+} from './types';
 import { parseBatchLookupRequests } from './validation';
 import { type GeocodeBatchResult } from './geocoding';
 import { incrementMetric, recordTiming } from './metrics';
-import { performExpandedLookup, type NormalizedAddressContext } from './lookup-expansion';
-import { resolveIncludeProvince } from './return-selector';
-
-// Type aliases for callback functions to avoid explicit any
-type GeocodeFunction = (env: Env, query: QueryParams, request?: Request) => Promise<{ lon: number; lat: number }>;
-type LookupRidingFunction = (env: Env, pathname: string, lon: number, lat: number) => Promise<LookupResult>;
-type CircuitBreakerExecutor = { execute: (key: string, fn: () => Promise<unknown>) => Promise<unknown> };
+import {
+  performExpandedLookup,
+  expandedLookupResponseFields,
+  type NormalizedAddressContext,
+  type LookupRidingFn,
+} from './lookup-expansion';
 
 // Default batch size
 const DEFAULT_BATCH_SIZE = 10;
@@ -17,94 +25,48 @@ const DEFAULT_BATCH_SIZE = 10;
 export const MAX_BATCH_SIZE = 100;
 export const MAX_REQUEST_BODY_SIZE = 10 * 1024 * 1024; // 10MB
 
-// Process batch lookup with individual geocoding
-export async function processBatchLookup(
-  env: Env, 
-  requests: BatchLookupRequest[],
-  geocodeIfNeeded: GeocodeFunction,
-  lookupRiding: LookupRidingFunction
-): Promise<BatchLookupResponse[]> {
-  // Validate batch size
-  if (requests.length > MAX_BATCH_SIZE) {
-    throw new Error(`Batch size exceeds maximum of ${MAX_BATCH_SIZE} requests`);
-  }
-  
-  const results: BatchLookupResponse[] = [];
-  // Validate and clamp batch size from environment
-  const rawBatchSize = env.BATCH_SIZE || DEFAULT_BATCH_SIZE;
-  const batchSize = Math.max(1, Math.min(Math.floor(rawBatchSize), MAX_BATCH_SIZE));
-  
-  incrementMetric('batchRequests');
-  const startTime = Date.now();
-  
-  try {
-    // Process requests in chunks to avoid overwhelming the system
-    for (let i = 0; i < requests.length; i += batchSize) {
-      const chunk = requests.slice(i, i + batchSize);
-      const chunkPromises = chunk.map(async (req) => {
-        const startTime = Date.now();
-        try {
-          const { lon, lat } = await geocodeIfNeeded(env, req.query);
-          const result = await lookupRiding(env, req.pathname, lon, lat);
-          const processingTime = Date.now() - startTime;
-          
-          return {
-            id: req.id,
-            query: req.query,
-            point: { lon, lat },
-            properties: result.properties,
-            processingTime
-          } as BatchLookupResponse;
-        } catch (error) {
-          const processingTime = Date.now() - startTime;
-          return {
-            id: req.id,
-            query: req.query,
-            properties: null,
-            error: error instanceof Error ? error.message : "Unknown error",
-            processingTime
-          } as BatchLookupResponse;
-        }
-      });
-      
-      const chunkResults = await Promise.all(chunkPromises);
-      results.push(...chunkResults);
-    }
-    
-    recordTiming('totalBatchTime', Date.now() - startTime);
-    return results;
-  } catch (error) {
-    incrementMetric('batchErrors');
-    recordTiming('totalBatchTime', Date.now() - startTime);
-    throw error;
-  }
-}
-
 // Process batch lookup with batch geocoding (GeoGratis-first). Optional normalization via Google when key configured.
 export async function processBatchLookupWithBatchGeocoding(
   env: Env,
   requests: BatchLookupRequest[],
-  geocodeIfNeeded: (env: Env, query: QueryParams, request?: Request) => Promise<{ lon: number; lat: number; normalizedAddress?: string; addressComponents?: GoogleAddressComponents }>,
-  lookupRiding: LookupRidingFunction,
-  geocodeBatchFn: (env: Env, queries: QueryParams[], request?: Request, circuitBreaker?: CircuitBreakerExecutor) => Promise<GeocodeBatchResult[]>,
+  geocodeIfNeeded: (
+    env: Env,
+    query: QueryParams,
+    request?: Request
+  ) => Promise<{
+    lon: number;
+    lat: number;
+    normalizedAddress?: string;
+    addressComponents?: GoogleAddressComponents;
+  }>,
+  lookupRiding: LookupRidingFn,
+  geocodeBatchFn: (
+    env: Env,
+    queries: QueryParams[],
+    request?: Request,
+    circuitBreaker?: CircuitBreakerExecutor
+  ) => Promise<GeocodeBatchResult[]>,
   request?: Request,
   circuitBreaker?: CircuitBreakerExecutor
 ): Promise<BatchLookupResponse[]> {
-  // Validate batch size
   if (requests.length > MAX_BATCH_SIZE) {
     throw new Error(`Batch size exceeds maximum of ${MAX_BATCH_SIZE} requests`);
   }
-  
+
   const results: BatchLookupResponse[] = [];
-  
+
   incrementMetric('batchRequests');
   const startTime = Date.now();
-  
+
   try {
-    // Group requests by geocoding needs
     const geocodingNeeded: Array<{ request: BatchLookupRequest; index: number }> = [];
-    const coordinatesProvided: Array<{ request: BatchLookupRequest; index: number; lon: number; lat: number }> = [];
-    
+    const coordinatesProvided: Array<{
+      request: BatchLookupRequest;
+      index: number;
+      lon: number;
+      lat: number;
+    }> = [];
+
     for (let i = 0; i < requests.length; i++) {
       const req = requests[i];
       if (req.query.lat !== undefined && req.query.lon !== undefined) {
@@ -112,30 +74,31 @@ export async function processBatchLookupWithBatchGeocoding(
           request: req,
           index: i,
           lon: req.query.lon,
-          lat: req.query.lat
+          lat: req.query.lat,
         });
       } else {
         geocodingNeeded.push({
           request: req,
-          index: i
+          index: i,
         });
       }
     }
-    
+
     const runExpandedLookup = async (
       batchReq: BatchLookupRequest,
       lon: number,
       lat: number,
       addressContext?: NormalizedAddressContext
-    ): Promise<Pick<BatchLookupResponse, 'point' | 'properties' | 'riding' | 'province_data' | 'municipality' | 'normalizedAddress' | 'addressComponents'>> => {
-      const returnFields = batchReq.query.returnFields ?? [];
-      const includeProvince = resolveIncludeProvince(batchReq.pathname, batchReq.query.includeProvince);
+    ): Promise<
+      Pick<
+        BatchLookupResponse,
+        'point' | 'properties' | 'riding' | 'province_data' | 'municipality' | 'normalizedAddress' | 'addressComponents'
+      >
+    > => {
       const expanded = await performExpandedLookup(
         env,
         batchReq.pathname,
         { ...batchReq.query, lon, lat },
-        returnFields,
-        includeProvince,
         lookupRiding,
         {
           lon,
@@ -147,50 +110,41 @@ export async function processBatchLookupWithBatchGeocoding(
       );
 
       return {
-        point: { lon, lat },
-        properties: expanded.properties,
-        riding: expanded.riding,
-        ...(expanded.province_data !== undefined && { province_data: expanded.province_data }),
-        ...(expanded.municipality && { municipality: expanded.municipality }),
-        ...(expanded.normalizedAddress && { normalizedAddress: expanded.normalizedAddress }),
-        ...(expanded.addressComponents && { addressComponents: expanded.addressComponents }),
+        point: expanded.point,
+        ...expandedLookupResponseFields(expanded),
       };
     };
 
-    // Process coordinates-provided requests immediately
-    for (const { request, index, lon, lat } of coordinatesProvided) {
-      const startTime = Date.now();
+    for (const { request: batchRequest, index, lon, lat } of coordinatesProvided) {
+      const itemStart = Date.now();
       try {
-        const payload = await runExpandedLookup(request, lon, lat);
+        const payload = await runExpandedLookup(batchRequest, lon, lat);
         results[index] = {
-          id: request.id,
-          query: request.query,
+          id: batchRequest.id,
+          query: batchRequest.query,
           ...payload,
-          processingTime: Date.now() - startTime,
+          processingTime: Date.now() - itemStart,
         };
-        continue;
       } catch (error) {
-        const processingTime = Date.now() - startTime;
         results[index] = {
-          id: request.id,
-          query: request.query,
+          id: batchRequest.id,
+          query: batchRequest.query,
           properties: null,
-          error: error instanceof Error ? error.message : "Lookup failed",
-          processingTime
+          error: error instanceof Error ? error.message : 'Lookup failed',
+          processingTime: Date.now() - itemStart,
         };
       }
     }
-    
-    // Process geocoding-needed requests in batches (GeoGratis-first via geocodeBatchFn)
+
     if (geocodingNeeded.length > 0) {
-      const queries = geocodingNeeded.map(item => item.request.query);
+      const queries = geocodingNeeded.map((item) => item.request.query);
       const geocodingResults = await geocodeBatchFn(env, queries, request, circuitBreaker);
-      
+
       for (let i = 0; i < geocodingNeeded.length; i++) {
-        const { request, index } = geocodingNeeded[i];
+        const { request: batchRequest, index } = geocodingNeeded[i];
         const geocodingResult = geocodingResults[i];
-        const startTime = Date.now();
-        
+        const itemStart = Date.now();
+
         if (geocodingResult.success) {
           try {
             const addressContext: NormalizedAddressContext = {
@@ -198,40 +152,38 @@ export async function processBatchLookupWithBatchGeocoding(
               addressComponents: geocodingResult.addressComponents,
             };
             const payload = await runExpandedLookup(
-              request,
+              batchRequest,
               geocodingResult.lon,
               geocodingResult.lat,
               addressContext
             );
             results[index] = {
-              id: request.id,
-              query: request.query,
+              id: batchRequest.id,
+              query: batchRequest.query,
               ...payload,
-              processingTime: Date.now() - startTime,
+              processingTime: Date.now() - itemStart,
             };
           } catch (error) {
-            const processingTime = Date.now() - startTime;
             results[index] = {
-              id: request.id,
-              query: request.query,
+              id: batchRequest.id,
+              query: batchRequest.query,
               properties: null,
-              error: error instanceof Error ? error.message : "Lookup failed",
-              processingTime
+              error: error instanceof Error ? error.message : 'Lookup failed',
+              processingTime: Date.now() - itemStart,
             };
           }
         } else {
-          const processingTime = Date.now() - startTime;
           results[index] = {
-            id: request.id,
-            query: request.query,
+            id: batchRequest.id,
+            query: batchRequest.query,
             properties: null,
-            error: geocodingResult.error || "Geocoding failed",
-            processingTime
+            error: geocodingResult.error || 'Geocoding failed',
+            processingTime: Date.now() - itemStart,
           };
         }
       }
     }
-    
+
     recordTiming('totalBatchTime', Date.now() - startTime);
     return results;
   } catch (error) {
@@ -248,23 +200,25 @@ export async function submitBatchToQueue(env: Env, requests: unknown): Promise<{
   if (validatedRequests.length > MAX_BATCH_SIZE) {
     throw new Error(`Batch size exceeds maximum of ${MAX_BATCH_SIZE} requests`);
   }
-  
+
   if (!env.QUEUE_MANAGER) {
-    throw new Error("Queue manager not configured");
+    throw new Error('Queue manager not configured');
   }
 
-  const queueManagerId = env.QUEUE_MANAGER.idFromName("main-queue");
+  const queueManagerId = env.QUEUE_MANAGER.idFromName('main-queue');
   const queueManager = env.QUEUE_MANAGER.get(queueManagerId);
-  
-  const response = await queueManager.fetch(new Request("https://queue.local/queue/submit", {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ requests: validatedRequests })
-  }));
+
+  const response = await queueManager.fetch(
+    new Request('https://queue.local/queue/submit', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ requests: validatedRequests }),
+    })
+  );
 
   if (!response.ok) {
-    const error = await response.json() as { error?: string };
-    throw new Error(error.error || "Failed to submit batch to queue");
+    const error = (await response.json()) as { error?: string };
+    throw new Error(error.error || 'Failed to submit batch to queue');
   }
 
   return await response.json();
@@ -272,17 +226,19 @@ export async function submitBatchToQueue(env: Env, requests: unknown): Promise<{
 
 export async function getBatchStatus(env: Env, batchId: string): Promise<unknown> {
   if (!env.QUEUE_MANAGER) {
-    throw new Error("Queue manager not configured");
+    throw new Error('Queue manager not configured');
   }
 
-  const queueManagerId = env.QUEUE_MANAGER.idFromName("main-queue");
+  const queueManagerId = env.QUEUE_MANAGER.idFromName('main-queue');
   const queueManager = env.QUEUE_MANAGER.get(queueManagerId);
-  
-  const response = await queueManager.fetch(new Request(`https://queue.local/queue/status?batchId=${batchId}`));
-  
+
+  const response = await queueManager.fetch(
+    new Request(`https://queue.local/queue/status?batchId=${batchId}`)
+  );
+
   if (!response.ok) {
-    const error = await response.json() as { error?: string };
-    throw new Error(error.error || "Failed to get batch status");
+    const error = (await response.json()) as { error?: string };
+    throw new Error(error.error || 'Failed to get batch status');
   }
 
   return await response.json();
@@ -290,27 +246,28 @@ export async function getBatchStatus(env: Env, batchId: string): Promise<unknown
 
 export async function processQueueJobs(env: Env, maxJobs: number = 10): Promise<unknown> {
   if (!env.QUEUE_MANAGER) {
-    throw new Error("Queue manager not configured");
+    throw new Error('Queue manager not configured');
   }
 
-  const queueManagerId = env.QUEUE_MANAGER.idFromName("main-queue");
+  const queueManagerId = env.QUEUE_MANAGER.idFromName('main-queue');
   const queueManager = env.QUEUE_MANAGER.get(queueManagerId);
-  
-  const response = await queueManager.fetch(new Request("https://queue.local/queue/process", {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ maxJobs })
-  }));
-  
+
+  const response = await queueManager.fetch(
+    new Request('https://queue.local/queue/process', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ maxJobs }),
+    })
+  );
+
   if (!response.ok) {
-    const error = await response.json() as { error?: string };
-    throw new Error(error.error || "Failed to process queue jobs");
+    const error = (await response.json()) as { error?: string };
+    throw new Error(error.error || 'Failed to process queue jobs');
   }
 
   return await response.json();
 }
 
-// Batch job management
 export function createBatchJob(requests: BatchLookupRequest[]): BatchJob {
   return {
     id: `batch_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`,
@@ -318,33 +275,37 @@ export function createBatchJob(requests: BatchLookupRequest[]): BatchJob {
     status: 'pending',
     createdAt: Date.now(),
     results: [],
-    errors: []
+    errors: [],
   };
 }
 
-export function updateBatchJobStatus(job: BatchJob, status: BatchJob['status'], results?: BatchLookupResponse[], errors?: string[]): BatchJob {
+export function updateBatchJobStatus(
+  job: BatchJob,
+  status: BatchJob['status'],
+  results?: BatchLookupResponse[],
+  errors?: string[]
+): BatchJob {
   const updatedJob = { ...job, status };
-  
+
   if (results) {
     updatedJob.results = results;
   }
-  
+
   if (errors) {
     updatedJob.errors = errors;
   }
-  
+
   if (status === 'completed' || status === 'failed') {
     updatedJob.completedAt = Date.now();
   }
-  
+
   return updatedJob;
 }
 
-// Batch processing configuration
 export const BATCH_CONFIG = {
   DEFAULT_BATCH_SIZE: 10,
   MAX_BATCH_SIZE: 100,
-  TIMEOUT: 300000, // 5 minutes
+  TIMEOUT: 300000,
   RETRY_ATTEMPTS: 3,
-  RETRY_DELAY: 1000 // 1 second
+  RETRY_DELAY: 1000,
 };

--- a/src/docs.ts
+++ b/src/docs.ts
@@ -571,6 +571,8 @@ print(data)</code></pre>
                     <div class="param"><strong>address</strong> - Full address to geocode</div>
                     <div class="param"><strong>lat/lon</strong> - Latitude and longitude coordinates</div>
                     <div class="param"><strong>city/state/country</strong> - Location components</div>
+                    <div class="param"><strong>include_province</strong> - Optional boolean to include provincial riding data</div>
+                    <div class="param"><strong>return</strong> - Optional comma-separated extras: <code>municipality</code></div>
                 </div>
             </div>
 
@@ -589,7 +591,7 @@ print(data)</code></pre>
                     <span class="url">/api/combined</span>
                     <span class="description">Federal + Ontario or Quebec Provincial</span>
                 </div>
-                <p>Returns federal riding data plus <code>province_data</code> when the federal feature’s PROV_TERR is Ontario or Quebec (supports abbreviations and full names).</p>
+                <p>Convenience endpoint equivalent to federal lookup with <code>include_province=true</code> by default. Also accepts <code>return=municipality</code> for municipality enrichment.</p>
             </div>
 
             <div class="endpoint-section">
@@ -1097,6 +1099,96 @@ export function createSwaggerUI(baseUrl: string): string {
 </html>`;
 }
 
+const RETURN_QUERY_PARAMETER = {
+  name: "return",
+  in: "query" as const,
+  description: "Optional comma-separated extra response fields. Supported: municipality.",
+  required: false,
+  schema: { type: "string", example: "municipality" },
+};
+
+const INCLUDE_PROVINCE_PARAMETER = {
+  name: "include_province",
+  in: "query" as const,
+  description:
+    "Optional boolean. When true, include matching Ontario or Quebec provincial data in province_data. /api/combined defaults to true.",
+  required: false,
+  schema: { type: "boolean", example: true },
+};
+
+const LOOKUP_QUERY_PARAMETERS = [
+  {
+    name: "postal",
+    in: "query" as const,
+    description: "Canadian postal code (e.g., K1A 0A6)",
+    required: false,
+    schema: { type: "string", example: "K1A 0A6" },
+  },
+  {
+    name: "address",
+    in: "query" as const,
+    description: "Street address",
+    required: false,
+    schema: { type: "string", example: "123 Main St, Toronto, ON" },
+  },
+  {
+    name: "lat",
+    in: "query" as const,
+    description: "Latitude",
+    required: false,
+    schema: { type: "number", example: 45.4215 },
+  },
+  {
+    name: "lon",
+    in: "query" as const,
+    description: "Longitude",
+    required: false,
+    schema: { type: "number", example: -75.6972 },
+  },
+  {
+    name: "city",
+    in: "query" as const,
+    description: "City name",
+    required: false,
+    schema: { type: "string", example: "Toronto" },
+  },
+  {
+    name: "state",
+    in: "query" as const,
+    description: "Province or state",
+    required: false,
+    schema: { type: "string", example: "Ontario" },
+  },
+  {
+    name: "country",
+    in: "query" as const,
+    description: "Country",
+    required: false,
+    schema: { type: "string", example: "Canada" },
+  },
+  INCLUDE_PROVINCE_PARAMETER,
+  RETURN_QUERY_PARAMETER,
+];
+
+const RETURN_RESPONSE_PROPERTIES = {
+  province_data: {
+    type: "object",
+    nullable: true,
+    description:
+      "Ontario or Quebec provincial riding when include_province=true and PROV_TERR maps to ON/QC",
+    properties: {
+      riding: { type: "string" },
+      properties: { type: "object", nullable: true },
+      dataset: { type: "string" },
+    },
+  },
+  municipality: {
+    type: "string",
+    nullable: true,
+    description: "Municipality when return includes municipality",
+  },
+};
+
 export function createOpenAPISpec(baseUrl: string) {
   return {
     openapi: "3.0.0",
@@ -1128,57 +1220,7 @@ export function createOpenAPISpec(baseUrl: string) {
           description:
             "Alias of /api/federal. Find the federal riding for a given location using postal code, address, or coordinates",
           tags: ["Federal Ridings"],
-          parameters: [
-            {
-              name: "postal",
-              in: "query",
-              description: "Canadian postal code (e.g., K1A 0A6)",
-              required: false,
-              schema: { type: "string", example: "K1A 0A6" },
-            },
-            {
-              name: "address",
-              in: "query",
-              description: "Street address",
-              required: false,
-              schema: { type: "string", example: "123 Main St, Toronto, ON" },
-            },
-            {
-              name: "lat",
-              in: "query",
-              description: "Latitude",
-              required: false,
-              schema: { type: "number", example: 45.4215 },
-            },
-            {
-              name: "lon",
-              in: "query",
-              description: "Longitude",
-              required: false,
-              schema: { type: "number", example: -75.6972 },
-            },
-            {
-              name: "city",
-              in: "query",
-              description: "City name",
-              required: false,
-              schema: { type: "string", example: "Toronto" },
-            },
-            {
-              name: "state",
-              in: "query",
-              description: "Province or state",
-              required: false,
-              schema: { type: "string", example: "Ontario" },
-            },
-            {
-              name: "country",
-              in: "query",
-              description: "Country",
-              required: false,
-              schema: { type: "string", example: "Canada" },
-            },
-          ],
+          parameters: LOOKUP_QUERY_PARAMETERS,
           responses: {
             "200": {
               description: "Successful lookup",
@@ -1205,6 +1247,7 @@ export function createOpenAPISpec(baseUrl: string) {
                           "Riding properties including FED_NUM, FED_NAME, etc.",
                         nullable: true,
                       },
+                      ...RETURN_RESPONSE_PROPERTIES,
                     },
                   },
                   example: {
@@ -1269,57 +1312,7 @@ export function createOpenAPISpec(baseUrl: string) {
           description:
             "Find the federal riding for a given location using postal code, address, or coordinates",
           tags: ["Federal Ridings"],
-          parameters: [
-            {
-              name: "postal",
-              in: "query",
-              description: "Canadian postal code (e.g., K1A 0A6)",
-              required: false,
-              schema: { type: "string", example: "K1A 0A6" },
-            },
-            {
-              name: "address",
-              in: "query",
-              description: "Street address",
-              required: false,
-              schema: { type: "string", example: "123 Main St, Toronto, ON" },
-            },
-            {
-              name: "lat",
-              in: "query",
-              description: "Latitude",
-              required: false,
-              schema: { type: "number", example: 45.4215 },
-            },
-            {
-              name: "lon",
-              in: "query",
-              description: "Longitude",
-              required: false,
-              schema: { type: "number", example: -75.6972 },
-            },
-            {
-              name: "city",
-              in: "query",
-              description: "City name",
-              required: false,
-              schema: { type: "string", example: "Toronto" },
-            },
-            {
-              name: "state",
-              in: "query",
-              description: "Province or state",
-              required: false,
-              schema: { type: "string", example: "Ontario" },
-            },
-            {
-              name: "country",
-              in: "query",
-              description: "Country",
-              required: false,
-              schema: { type: "string", example: "Canada" },
-            },
-          ],
+          parameters: LOOKUP_QUERY_PARAMETERS,
           responses: {
             "200": {
               description: "Successful lookup",
@@ -1346,6 +1339,7 @@ export function createOpenAPISpec(baseUrl: string) {
                           "Riding properties including FED_NUM, FED_NAME, etc.",
                         nullable: true,
                       },
+                      ...RETURN_RESPONSE_PROPERTIES,
                     },
                   },
                   example: {
@@ -1460,6 +1454,8 @@ export function createOpenAPISpec(baseUrl: string) {
               required: false,
               schema: { type: "string", example: "Canada" },
             },
+            INCLUDE_PROVINCE_PARAMETER,
+            RETURN_QUERY_PARAMETER,
           ],
           responses: {
             "200": {
@@ -1590,6 +1586,8 @@ export function createOpenAPISpec(baseUrl: string) {
               required: false,
               schema: { type: "number", example: -73.5673 },
             },
+            INCLUDE_PROVINCE_PARAMETER,
+            RETURN_QUERY_PARAMETER,
           ],
           responses: {
             "200": {
@@ -1611,6 +1609,7 @@ export function createOpenAPISpec(baseUrl: string) {
                         type: "object",
                         nullable: true,
                       },
+                      ...RETURN_RESPONSE_PROPERTIES,
                     },
                   },
                 },
@@ -1655,6 +1654,8 @@ export function createOpenAPISpec(baseUrl: string) {
               required: false,
               schema: { type: "number", example: -79.3832 },
             },
+            INCLUDE_PROVINCE_PARAMETER,
+            RETURN_QUERY_PARAMETER,
           ],
           responses: {
             "200": {
@@ -1676,6 +1677,7 @@ export function createOpenAPISpec(baseUrl: string) {
                         type: "object",
                         nullable: true,
                       },
+                      ...RETURN_RESPONSE_PROPERTIES,
                     },
                   },
                 },
@@ -1778,6 +1780,15 @@ export function createOpenAPISpec(baseUrl: string) {
                               city: { type: "string" },
                               state: { type: "string" },
                               country: { type: "string" },
+                              return: {
+                                type: "string",
+                                description: "Optional comma-separated extras: municipality",
+                              },
+                              include_province: {
+                                type: "boolean",
+                                description:
+                                  "Optional boolean. When true, include matching provincial data in province_data",
+                              },
                             },
                           },
                         },
@@ -1854,6 +1865,15 @@ export function createOpenAPISpec(baseUrl: string) {
                               city: { type: "string" },
                               state: { type: "string" },
                               country: { type: "string" },
+                              return: {
+                                type: "string",
+                                description: "Optional comma-separated extras: municipality",
+                              },
+                              include_province: {
+                                type: "boolean",
+                                description:
+                                  "Optional boolean. When true, include matching provincial data in province_data",
+                              },
                             },
                           },
                         },

--- a/src/lookup-expansion.ts
+++ b/src/lookup-expansion.ts
@@ -4,11 +4,11 @@ import {
   LookupResult,
   GoogleAddressComponents,
   CanadaPostStyleAddress,
-  TimeoutConfig,
+  CircuitBreakerExecutor,
 } from './types';
 import { generateLookupCacheKey, getCachedLookupResult, setCachedLookupResult } from './cache';
-import { pickDataset, provincePathFromFederalProperties } from './utils';
-import { isFederalLookupPath, ReturnField, wantsReturnField } from './return-selector';
+import { pickDataset, provincePathFromFederalProperties, withTimeout } from './utils';
+import { resolveLookupPath } from './return-selector';
 import { resolveNormalizedAddress } from './oda-handlers';
 import { isOdaEnabled } from './oda-config';
 import { normalizeAddressWithGoogle } from './geocoding';
@@ -36,24 +36,40 @@ export interface ExpandedLookupPayload {
   cacheStatus: 'HIT' | 'MISS' | 'PARTIAL';
 }
 
-type LookupRidingFn = (
+export type LookupRidingFn = (
   env: Env,
   pathname: string,
   lon: number,
   lat: number
 ) => Promise<LookupResult>;
 
-type CircuitBreakerExecutor = {
-  execute: (key: string, fn: () => Promise<unknown>) => Promise<unknown>;
+export type GeocodeIfNeededFn = (
+  env: Env,
+  query: QueryParams,
+  request?: Request,
+  circuitBreaker?: CircuitBreakerExecutor
+) => Promise<{
+  lon: number;
+  lat: number;
+  normalizedAddress?: string;
+  addressComponents?: GoogleAddressComponents;
+  mailingAddress?: CanadaPostStyleAddress;
+}>;
+
+type ProvinceFetchResult = {
+  data: ProvinceData | null;
+  cacheHit: boolean;
 };
 
-const FEDERAL_PATH = '/api/federal';
-
-function baseLookupPathname(pathname: string): string {
-  if (pathname === '/api' || pathname === '/api/combined') {
-    return FEDERAL_PATH;
-  }
-  return pathname;
+function provinceDataFromCache(
+  cachedProv: LookupResult,
+  provincePath: string
+): ProvinceData {
+  return {
+    riding: cachedProv.riding ?? '',
+    properties: cachedProv.properties ?? {},
+    dataset: pickDataset(provincePath).r2Key.replace('.geojson', ''),
+  };
 }
 
 export function extractMunicipality(
@@ -128,21 +144,17 @@ export async function fetchProvinceData(
   federalProperties: Record<string, unknown> | null,
   query: QueryParams,
   lookupRiding: LookupRidingFn
-): Promise<ProvinceData | null> {
+): Promise<ProvinceFetchResult> {
   const provincePath = provincePathFromFederalProperties(federalProperties);
   if (!provincePath) {
-    return null;
+    return { data: null, cacheHit: false };
   }
 
   const provinceCacheKey = generateLookupCacheKey({ ...query, lon, lat }, provincePath);
   const cachedProv = await getCachedLookupResult(env, provinceCacheKey);
   if (cachedProv) {
     incrementMetric('lookupCacheHits');
-    return {
-      riding: cachedProv.riding ?? '',
-      properties: (cachedProv.properties || {}) as Record<string, unknown>,
-      dataset: pickDataset(provincePath).r2Key.replace('.geojson', ''),
-    };
+    return { data: provinceDataFromCache(cachedProv, provincePath), cacheHit: true };
   }
 
   incrementMetric('lookupCacheMisses');
@@ -156,18 +168,39 @@ export async function fetchProvinceData(
     };
     await setCachedLookupResult(env, provinceCacheKey, toCache, dataset, { lon, lat });
     return {
-      riding: provLookup.riding ?? '',
-      properties: (provLookup.properties || {}) as Record<string, unknown>,
-      dataset,
+      data: {
+        riding: provLookup.riding ?? '',
+        properties: provLookup.properties ?? {},
+        dataset,
+      },
+      cacheHit: false,
     };
   } catch {
-    return null;
+    return { data: null, cacheHit: false };
   }
+}
+
+function computeCombinedCacheStatus(
+  federalCacheHit: boolean,
+  needsProvince: boolean,
+  provinceCacheHit: boolean,
+  provinceData: ProvinceData | null | undefined
+): 'HIT' | 'MISS' | 'PARTIAL' {
+  if (!needsProvince) {
+    return federalCacheHit ? 'HIT' : 'MISS';
+  }
+  if (federalCacheHit && (provinceCacheHit || provinceData === null)) {
+    return 'HIT';
+  }
+  if (federalCacheHit || provinceCacheHit) {
+    return 'PARTIAL';
+  }
+  return 'MISS';
 }
 
 export function buildExpandedLookupPayload(
   base: LookupResult,
-  returnFields: ReturnField[],
+  returnFields: readonly string[],
   lookupPathname: string,
   options: {
     includeProvince?: boolean;
@@ -178,7 +211,7 @@ export function buildExpandedLookupPayload(
   } = {}
 ): ExpandedLookupPayload {
   const includeProvince = options.includeProvince ?? false;
-  const includeMunicipality = wantsReturnField(returnFields, 'municipality');
+  const includeMunicipality = returnFields.includes('municipality');
 
   const addressContext = options.addressContext ?? {};
   const municipality = includeMunicipality
@@ -190,8 +223,8 @@ export function buildExpandedLookupPayload(
     : undefined;
 
   const properties = includeMunicipality
-    ? applyMunicipalityToProperties(base.properties as Record<string, unknown> | null, municipality)
-    : (base.properties as Record<string, unknown> | null);
+    ? applyMunicipalityToProperties(base.properties, municipality)
+    : base.properties;
 
   const payload: ExpandedLookupPayload = {
     riding: base.riding,
@@ -199,7 +232,7 @@ export function buildExpandedLookupPayload(
     cacheStatus: options.cacheStatus ?? 'MISS',
   };
 
-  if (includeProvince && isFederalLookupPath(lookupPathname)) {
+  if (includeProvince && resolveLookupPath(lookupPathname).isFederal) {
     payload.province_data = options.provinceData ?? null;
   }
 
@@ -219,50 +252,117 @@ export function buildExpandedLookupPayload(
   return payload;
 }
 
+/** Response fields shared by HTTP lookup and batch lookup. */
+export function expandedLookupResponseFields(expanded: ExpandedLookupPayload): {
+  riding?: string;
+  properties: Record<string, unknown> | null;
+  province_data?: ProvinceData | null;
+  municipality?: string;
+  normalizedAddress?: string;
+  addressComponents?: GoogleAddressComponents;
+} {
+  return {
+    riding: expanded.riding,
+    properties: expanded.properties,
+    ...(expanded.province_data !== undefined && { province_data: expanded.province_data }),
+    ...(expanded.municipality && { municipality: expanded.municipality }),
+    ...(expanded.normalizedAddress && { normalizedAddress: expanded.normalizedAddress }),
+    ...(expanded.addressComponents && { addressComponents: expanded.addressComponents }),
+  };
+}
+
+async function resolveCoordinates(
+  env: Env,
+  sanitizedQuery: QueryParams,
+  cachedPoint: { lon: number; lat: number } | undefined,
+  options: {
+    lon?: number;
+    lat?: number;
+    request?: Request;
+    circuitBreaker?: CircuitBreakerExecutor;
+    geocodeIfNeeded?: GeocodeIfNeededFn;
+    geocodingTimeoutMs?: number;
+    addressContext?: NormalizedAddressContext;
+  }
+): Promise<{ lon: number; lat: number; addressContext?: NormalizedAddressContext }> {
+  if (options.lon !== undefined && options.lat !== undefined) {
+    return { lon: options.lon, lat: options.lat, addressContext: options.addressContext };
+  }
+  if (sanitizedQuery.lon !== undefined && sanitizedQuery.lat !== undefined) {
+    return {
+      lon: sanitizedQuery.lon,
+      lat: sanitizedQuery.lat,
+      addressContext: options.addressContext,
+    };
+  }
+  if (cachedPoint) {
+    return { lon: cachedPoint.lon, lat: cachedPoint.lat, addressContext: options.addressContext };
+  }
+  if (!options.geocodeIfNeeded || options.geocodingTimeoutMs === undefined) {
+    throw new Error('Coordinates required: provide lat/lon or enable geocoding');
+  }
+  const geocodeResult = await withTimeout(
+    options.geocodeIfNeeded(env, sanitizedQuery, options.request, options.circuitBreaker),
+    options.geocodingTimeoutMs,
+    'Geocoding'
+  );
+  return {
+    lon: geocodeResult.lon,
+    lat: geocodeResult.lat,
+    addressContext: {
+      normalizedAddress: geocodeResult.normalizedAddress,
+      addressComponents: geocodeResult.addressComponents,
+      mailingAddress: geocodeResult.mailingAddress,
+      ...options.addressContext,
+    },
+  };
+}
+
 export async function performExpandedLookup(
   env: Env,
   lookupPathname: string,
   sanitizedQuery: QueryParams,
-  returnFields: ReturnField[],
-  includeProvince: boolean,
   lookupRiding: LookupRidingFn,
   options: {
-    lon: number;
-    lat: number;
+    lon?: number;
+    lat?: number;
     request?: Request;
     circuitBreaker?: CircuitBreakerExecutor;
-    timeoutConfig?: TimeoutConfig;
-    preloadedResult?: LookupResult;
-    preloadedCacheStatus?: 'HIT' | 'MISS' | 'PARTIAL';
+    geocodeIfNeeded?: GeocodeIfNeededFn;
+    geocodingTimeoutMs?: number;
     addressContext?: NormalizedAddressContext;
-  }
-): Promise<ExpandedLookupPayload> {
-  const basePath = baseLookupPathname(lookupPathname);
-  const cacheKey = generateLookupCacheKey(sanitizedQuery, basePath);
+  } = {}
+): Promise<ExpandedLookupPayload & { point: { lon: number; lat: number } }> {
+  const { datasetPath, isFederal } = resolveLookupPath(lookupPathname);
+  const returnFields = sanitizedQuery.returnFields ?? [];
+  const includeProvince = sanitizedQuery.includeProvince ?? false;
+  const cacheKey = generateLookupCacheKey(sanitizedQuery, datasetPath);
+  const cached = await getCachedLookupResult(env, cacheKey);
 
-  let baseResult = options.preloadedResult;
-  let cacheStatus = options.preloadedCacheStatus ?? 'MISS';
-  const federalCacheHit = cacheStatus === 'HIT';
+  const { lon, lat, addressContext: resolvedAddressContext } = await resolveCoordinates(
+    env,
+    sanitizedQuery,
+    cached?.point,
+    options
+  );
 
-  if (!baseResult) {
-    const cached = await getCachedLookupResult(env, cacheKey);
-    if (cached) {
-      incrementMetric('lookupCacheHits');
-      cacheStatus = 'HIT';
-      baseResult = {
-        properties: cached.properties,
-        riding: cached.riding,
-        normalizedAddress: cached.normalizedAddress,
-        addressComponents: cached.addressComponents,
-      };
-    }
-  }
+  let baseResult: LookupResult;
+  let federalCacheHit = false;
 
-  if (!baseResult) {
+  if (cached) {
+    incrementMetric('lookupCacheHits');
+    federalCacheHit = true;
+    baseResult = {
+      properties: cached.properties,
+      riding: cached.riding,
+      normalizedAddress: cached.normalizedAddress,
+      addressComponents: cached.addressComponents,
+    };
+  } else {
     incrementMetric('lookupCacheMisses');
-    const lookup = await lookupRiding(env, basePath, options.lon, options.lat);
+    const lookup = await lookupRiding(env, datasetPath, lon, lat);
     baseResult = lookup;
-    const { r2Key } = pickDataset(basePath);
+    const { r2Key } = pickDataset(datasetPath);
     const dataset = r2Key.replace('.geojson', '');
     await setCachedLookupResult(
       env,
@@ -274,19 +374,19 @@ export async function performExpandedLookup(
         addressComponents: lookup.addressComponents,
       },
       dataset,
-      { lon: options.lon, lat: options.lat }
+      { lon, lat }
     );
   }
 
-  const needsMunicipality = wantsReturnField(returnFields, 'municipality');
-  const needsProvince = includeProvince && isFederalLookupPath(lookupPathname);
+  const needsMunicipality = returnFields.includes('municipality');
+  const needsProvince = includeProvince && isFederal;
 
-  let addressContext = options.addressContext;
+  let addressContext = resolvedAddressContext;
   if (needsMunicipality) {
     addressContext = await resolveAddressContext(
       env,
-      options.lat,
-      options.lon,
+      lat,
+      lon,
       sanitizedQuery,
       options.request,
       options.circuitBreaker,
@@ -297,51 +397,32 @@ export async function performExpandedLookup(
   let provinceData: ProvinceData | null | undefined;
   let provinceCacheHit = false;
   if (needsProvince) {
-    const provincePath = provincePathFromFederalProperties(baseResult.properties as Record<string, unknown> | null);
-    if (provincePath) {
-      const provinceCacheKey = generateLookupCacheKey(
-        { ...sanitizedQuery, lon: options.lon, lat: options.lat },
-        provincePath
-      );
-      const cachedProv = await getCachedLookupResult(env, provinceCacheKey);
-      provinceCacheHit = !!cachedProv;
-      if (cachedProv) {
-        incrementMetric('lookupCacheHits');
-        provinceData = {
-          riding: cachedProv.riding ?? '',
-          properties: (cachedProv.properties || {}) as Record<string, unknown>,
-          dataset: pickDataset(provincePath).r2Key.replace('.geojson', ''),
-        };
-      } else {
-        provinceData = await fetchProvinceData(
-          env,
-          options.lon,
-          options.lat,
-          baseResult.properties as Record<string, unknown> | null,
-          sanitizedQuery,
-          lookupRiding
-        );
-      }
-    } else {
-      provinceData = null;
-    }
-
-    if (federalCacheHit && (provinceCacheHit || provinceData === null)) {
-      cacheStatus = 'HIT';
-    } else if (federalCacheHit || provinceCacheHit) {
-      cacheStatus = 'PARTIAL';
-    } else {
-      cacheStatus = 'MISS';
-    }
-  } else if (federalCacheHit) {
-    cacheStatus = 'HIT';
+    const result = await fetchProvinceData(
+      env,
+      lon,
+      lat,
+      baseResult.properties,
+      sanitizedQuery,
+      lookupRiding
+    );
+    provinceData = result.data;
+    provinceCacheHit = result.cacheHit;
   }
 
-  return buildExpandedLookupPayload(baseResult, returnFields, lookupPathname, {
+  const cacheStatus = computeCombinedCacheStatus(
+    federalCacheHit,
+    needsProvince,
+    provinceCacheHit,
+    provinceData
+  );
+
+  const payload = buildExpandedLookupPayload(baseResult, returnFields, lookupPathname, {
     includeProvince,
     provinceData,
     addressContext,
     queryCity: sanitizedQuery.city,
     cacheStatus,
   });
+
+  return { ...payload, point: { lon, lat } };
 }

--- a/src/lookup-expansion.ts
+++ b/src/lookup-expansion.ts
@@ -1,0 +1,347 @@
+import {
+  Env,
+  QueryParams,
+  LookupResult,
+  GoogleAddressComponents,
+  CanadaPostStyleAddress,
+  TimeoutConfig,
+} from './types';
+import { generateLookupCacheKey, getCachedLookupResult, setCachedLookupResult } from './cache';
+import { pickDataset, provincePathFromFederalProperties } from './utils';
+import { isFederalLookupPath, ReturnField, wantsReturnField } from './return-selector';
+import { resolveNormalizedAddress } from './oda-handlers';
+import { isOdaEnabled } from './oda-config';
+import { normalizeAddressWithGoogle } from './geocoding';
+import { incrementMetric } from './metrics';
+
+export type ProvinceData = {
+  riding: string;
+  properties: Record<string, unknown>;
+  dataset: string;
+};
+
+export interface NormalizedAddressContext {
+  normalizedAddress?: string;
+  addressComponents?: GoogleAddressComponents;
+  mailingAddress?: CanadaPostStyleAddress;
+}
+
+export interface ExpandedLookupPayload {
+  riding?: string;
+  properties: Record<string, unknown> | null;
+  province_data?: ProvinceData | null;
+  municipality?: string;
+  normalizedAddress?: string;
+  addressComponents?: GoogleAddressComponents;
+  cacheStatus: 'HIT' | 'MISS' | 'PARTIAL';
+}
+
+type LookupRidingFn = (
+  env: Env,
+  pathname: string,
+  lon: number,
+  lat: number
+) => Promise<LookupResult>;
+
+type CircuitBreakerExecutor = {
+  execute: (key: string, fn: () => Promise<unknown>) => Promise<unknown>;
+};
+
+const FEDERAL_PATH = '/api/federal';
+
+function baseLookupPathname(pathname: string): string {
+  if (pathname === '/api' || pathname === '/api/combined') {
+    return FEDERAL_PATH;
+  }
+  return pathname;
+}
+
+export function extractMunicipality(
+  addressComponents?: GoogleAddressComponents,
+  mailingAddress?: CanadaPostStyleAddress,
+  queryCity?: string
+): string | undefined {
+  if (mailingAddress?.municipality) {
+    return mailingAddress.municipality;
+  }
+  if (addressComponents?.locality) {
+    return addressComponents.locality;
+  }
+  if (queryCity) {
+    return queryCity;
+  }
+  return undefined;
+}
+
+export function applyMunicipalityToProperties(
+  properties: Record<string, unknown> | null,
+  municipality?: string
+): Record<string, unknown> | null {
+  if (!municipality || !properties) {
+    return properties;
+  }
+  return { ...properties, MUNICIPALITY: municipality };
+}
+
+export async function resolveAddressContext(
+  env: Env,
+  lat: number,
+  lon: number,
+  query: QueryParams,
+  request?: Request,
+  circuitBreaker?: CircuitBreakerExecutor,
+  existing?: NormalizedAddressContext
+): Promise<NormalizedAddressContext> {
+  if (existing?.normalizedAddress || existing?.addressComponents || existing?.mailingAddress) {
+    return existing;
+  }
+
+  if (isOdaEnabled(env)) {
+    const odaNorm = await resolveNormalizedAddress(env, lat, lon, query, request, circuitBreaker);
+    if (odaNorm) {
+      return {
+        normalizedAddress: odaNorm.normalizedAddress,
+        addressComponents: odaNorm.addressComponents,
+        mailingAddress: odaNorm.mailingAddress,
+      };
+    }
+    return {};
+  }
+
+  if (request?.headers.get('X-Google-API-Key') || env.GOOGLE_MAPS_KEY) {
+    const googleResult = await normalizeAddressWithGoogle(env, lat, lon, request, circuitBreaker);
+    if (googleResult) {
+      return {
+        normalizedAddress: googleResult.formattedAddress,
+        addressComponents: googleResult.components,
+      };
+    }
+  }
+
+  return {};
+}
+
+export async function fetchProvinceData(
+  env: Env,
+  lon: number,
+  lat: number,
+  federalProperties: Record<string, unknown> | null,
+  query: QueryParams,
+  lookupRiding: LookupRidingFn
+): Promise<ProvinceData | null> {
+  const provincePath = provincePathFromFederalProperties(federalProperties);
+  if (!provincePath) {
+    return null;
+  }
+
+  const provinceCacheKey = generateLookupCacheKey({ ...query, lon, lat }, provincePath);
+  const cachedProv = await getCachedLookupResult(env, provinceCacheKey);
+  if (cachedProv) {
+    incrementMetric('lookupCacheHits');
+    return {
+      riding: cachedProv.riding ?? '',
+      properties: (cachedProv.properties || {}) as Record<string, unknown>,
+      dataset: pickDataset(provincePath).r2Key.replace('.geojson', ''),
+    };
+  }
+
+  incrementMetric('lookupCacheMisses');
+  try {
+    const provLookup = await lookupRiding(env, provincePath, lon, lat);
+    const { r2Key } = pickDataset(provincePath);
+    const dataset = r2Key.replace('.geojson', '');
+    const toCache: LookupResult = {
+      properties: provLookup.properties,
+      riding: provLookup.riding,
+    };
+    await setCachedLookupResult(env, provinceCacheKey, toCache, dataset, { lon, lat });
+    return {
+      riding: provLookup.riding ?? '',
+      properties: (provLookup.properties || {}) as Record<string, unknown>,
+      dataset,
+    };
+  } catch {
+    return null;
+  }
+}
+
+export function buildExpandedLookupPayload(
+  base: LookupResult,
+  returnFields: ReturnField[],
+  lookupPathname: string,
+  options: {
+    includeProvince?: boolean;
+    provinceData?: ProvinceData | null;
+    addressContext?: NormalizedAddressContext;
+    queryCity?: string;
+    cacheStatus?: 'HIT' | 'MISS' | 'PARTIAL';
+  } = {}
+): ExpandedLookupPayload {
+  const includeProvince = options.includeProvince ?? false;
+  const includeMunicipality = wantsReturnField(returnFields, 'municipality');
+
+  const addressContext = options.addressContext ?? {};
+  const municipality = includeMunicipality
+    ? extractMunicipality(
+        addressContext.addressComponents ?? base.addressComponents,
+        addressContext.mailingAddress,
+        options.queryCity
+      )
+    : undefined;
+
+  const properties = includeMunicipality
+    ? applyMunicipalityToProperties(base.properties as Record<string, unknown> | null, municipality)
+    : (base.properties as Record<string, unknown> | null);
+
+  const payload: ExpandedLookupPayload = {
+    riding: base.riding,
+    properties,
+    cacheStatus: options.cacheStatus ?? 'MISS',
+  };
+
+  if (includeProvince && isFederalLookupPath(lookupPathname)) {
+    payload.province_data = options.provinceData ?? null;
+  }
+
+  if (includeMunicipality && municipality) {
+    payload.municipality = municipality;
+  }
+
+  const normalizedAddress = addressContext.normalizedAddress ?? base.normalizedAddress;
+  const addressComponents = addressContext.addressComponents ?? base.addressComponents;
+  if (normalizedAddress) {
+    payload.normalizedAddress = normalizedAddress;
+  }
+  if (addressComponents) {
+    payload.addressComponents = addressComponents;
+  }
+
+  return payload;
+}
+
+export async function performExpandedLookup(
+  env: Env,
+  lookupPathname: string,
+  sanitizedQuery: QueryParams,
+  returnFields: ReturnField[],
+  includeProvince: boolean,
+  lookupRiding: LookupRidingFn,
+  options: {
+    lon: number;
+    lat: number;
+    request?: Request;
+    circuitBreaker?: CircuitBreakerExecutor;
+    timeoutConfig?: TimeoutConfig;
+    preloadedResult?: LookupResult;
+    preloadedCacheStatus?: 'HIT' | 'MISS' | 'PARTIAL';
+    addressContext?: NormalizedAddressContext;
+  }
+): Promise<ExpandedLookupPayload> {
+  const basePath = baseLookupPathname(lookupPathname);
+  const cacheKey = generateLookupCacheKey(sanitizedQuery, basePath);
+
+  let baseResult = options.preloadedResult;
+  let cacheStatus = options.preloadedCacheStatus ?? 'MISS';
+  const federalCacheHit = cacheStatus === 'HIT';
+
+  if (!baseResult) {
+    const cached = await getCachedLookupResult(env, cacheKey);
+    if (cached) {
+      incrementMetric('lookupCacheHits');
+      cacheStatus = 'HIT';
+      baseResult = {
+        properties: cached.properties,
+        riding: cached.riding,
+        normalizedAddress: cached.normalizedAddress,
+        addressComponents: cached.addressComponents,
+      };
+    }
+  }
+
+  if (!baseResult) {
+    incrementMetric('lookupCacheMisses');
+    const lookup = await lookupRiding(env, basePath, options.lon, options.lat);
+    baseResult = lookup;
+    const { r2Key } = pickDataset(basePath);
+    const dataset = r2Key.replace('.geojson', '');
+    await setCachedLookupResult(
+      env,
+      cacheKey,
+      {
+        properties: lookup.properties,
+        riding: lookup.riding,
+        normalizedAddress: lookup.normalizedAddress,
+        addressComponents: lookup.addressComponents,
+      },
+      dataset,
+      { lon: options.lon, lat: options.lat }
+    );
+  }
+
+  const needsMunicipality = wantsReturnField(returnFields, 'municipality');
+  const needsProvince = includeProvince && isFederalLookupPath(lookupPathname);
+
+  let addressContext = options.addressContext;
+  if (needsMunicipality) {
+    addressContext = await resolveAddressContext(
+      env,
+      options.lat,
+      options.lon,
+      sanitizedQuery,
+      options.request,
+      options.circuitBreaker,
+      addressContext
+    );
+  }
+
+  let provinceData: ProvinceData | null | undefined;
+  let provinceCacheHit = false;
+  if (needsProvince) {
+    const provincePath = provincePathFromFederalProperties(baseResult.properties as Record<string, unknown> | null);
+    if (provincePath) {
+      const provinceCacheKey = generateLookupCacheKey(
+        { ...sanitizedQuery, lon: options.lon, lat: options.lat },
+        provincePath
+      );
+      const cachedProv = await getCachedLookupResult(env, provinceCacheKey);
+      provinceCacheHit = !!cachedProv;
+      if (cachedProv) {
+        incrementMetric('lookupCacheHits');
+        provinceData = {
+          riding: cachedProv.riding ?? '',
+          properties: (cachedProv.properties || {}) as Record<string, unknown>,
+          dataset: pickDataset(provincePath).r2Key.replace('.geojson', ''),
+        };
+      } else {
+        provinceData = await fetchProvinceData(
+          env,
+          options.lon,
+          options.lat,
+          baseResult.properties as Record<string, unknown> | null,
+          sanitizedQuery,
+          lookupRiding
+        );
+      }
+    } else {
+      provinceData = null;
+    }
+
+    if (federalCacheHit && (provinceCacheHit || provinceData === null)) {
+      cacheStatus = 'HIT';
+    } else if (federalCacheHit || provinceCacheHit) {
+      cacheStatus = 'PARTIAL';
+    } else {
+      cacheStatus = 'MISS';
+    }
+  } else if (federalCacheHit) {
+    cacheStatus = 'HIT';
+  }
+
+  return buildExpandedLookupPayload(baseResult, returnFields, lookupPathname, {
+    includeProvince,
+    provinceData,
+    addressContext,
+    queryCity: sanitizedQuery.city,
+    cacheStatus,
+  });
+}

--- a/src/lookup-handler.ts
+++ b/src/lookup-handler.ts
@@ -1,0 +1,79 @@
+import { Env } from './types';
+import { geocodeIfNeeded } from './geocoding';
+import { geocodingCircuitBreaker } from './circuit-breaker';
+import { incrementMetric, recordTiming } from './metrics';
+import { parseQuery, badRequest } from './utils';
+import { getTimeoutConfig } from './config';
+import {
+  performExpandedLookup,
+  expandedLookupResponseFields,
+  type LookupRidingFn,
+} from './lookup-expansion';
+import { resolveLookupPath } from './return-selector';
+
+export async function handleLookupRequest(
+  request: Request,
+  env: Env,
+  pathname: string,
+  lookupRiding: LookupRidingFn,
+  correlationId: string,
+  startTime: number,
+  getCorsHeaders: (origin?: string | null) => Record<string, string>
+): Promise<Response> {
+  const { lookupPathname } = resolveLookupPath(pathname);
+  const { validation } = parseQuery(request);
+
+  if (!validation.valid) {
+    return badRequest(validation.error || 'Invalid query parameters', 400, 'INVALID_QUERY', correlationId);
+  }
+
+  const sanitizedQuery = validation.sanitized!;
+  const origin = request.headers.get('Origin');
+
+  incrementMetric('lookupRequests');
+
+  const timeoutConfig = getTimeoutConfig(env);
+  const circuitBreaker = geocodingCircuitBreaker
+    ? {
+        execute: (key: string, fn: () => Promise<unknown>) =>
+          geocodingCircuitBreaker!.execute(key, fn),
+      }
+    : undefined;
+
+  try {
+    const expanded = await performExpandedLookup(env, lookupPathname, sanitizedQuery, lookupRiding, {
+      request,
+      circuitBreaker,
+      geocodeIfNeeded: (env, query, req, cb) =>
+        geocodeIfNeeded(env, query, req, undefined, cb),
+      geocodingTimeoutMs: timeoutConfig.geocoding,
+    });
+
+    recordTiming('totalLookupTime', Date.now() - startTime);
+
+    return new Response(
+      JSON.stringify({
+        query: sanitizedQuery,
+        point: expanded.point,
+        ...expandedLookupResponseFields(expanded),
+        correlationId,
+      }),
+      {
+        headers: {
+          'content-type': 'application/json; charset=UTF-8',
+          'X-Cache-Status': expanded.cacheStatus,
+          ...getCorsHeaders(origin),
+        },
+      }
+    );
+  } catch (error) {
+    incrementMetric('errorCount');
+    console.error(`[${correlationId}] Lookup error:`, error);
+    return badRequest(
+      error instanceof Error ? error.message : 'Lookup failed',
+      500,
+      'LOOKUP_ERROR',
+      correlationId
+    );
+  }
+}

--- a/src/return-selector.ts
+++ b/src/return-selector.ts
@@ -15,6 +15,30 @@ export interface IncludeProvinceParseResult {
   error?: string;
 }
 
+const FEDERAL_DATASET_PATH = '/api/federal';
+
+export interface ResolvedLookupPath {
+  /** Path used for routing and expansion semantics (/api → /api/federal) */
+  lookupPathname: string;
+  /** Path used for dataset lookup and cache keys */
+  datasetPath: string;
+  isFederal: boolean;
+}
+
+/**
+ * Canonical pathname resolution for lookup routes.
+ */
+export function resolveLookupPath(pathname: string): ResolvedLookupPath {
+  const lookupPathname = pathname === '/api' ? FEDERAL_DATASET_PATH : pathname;
+  const datasetPath =
+    pathname === '/api' || pathname === '/api/combined' ? FEDERAL_DATASET_PATH : pathname;
+  const isFederal =
+    pathname === '/api' ||
+    pathname === FEDERAL_DATASET_PATH ||
+    pathname === '/api/combined';
+  return { lookupPathname, datasetPath, isFederal };
+}
+
 /**
  * Parses a comma-separated `return` query value into supported expansion tokens.
  */
@@ -80,12 +104,4 @@ export function resolveIncludeProvince(
     return includeProvince;
   }
   return pathname === '/api/combined';
-}
-
-export function isFederalLookupPath(pathname: string): boolean {
-  return pathname === '/api' || pathname === '/api/federal' || pathname === '/api/combined';
-}
-
-export function wantsReturnField(fields: ReturnField[], field: ReturnField): boolean {
-  return fields.includes(field);
 }

--- a/src/return-selector.ts
+++ b/src/return-selector.ts
@@ -1,0 +1,91 @@
+export const RETURN_FIELD_TOKENS = ['municipality'] as const;
+
+export type ReturnField = (typeof RETURN_FIELD_TOKENS)[number];
+
+export interface ReturnSelectorParseResult {
+  valid: boolean;
+  fields: ReturnField[];
+  error?: string;
+}
+
+export interface IncludeProvinceParseResult {
+  valid: boolean;
+  /** undefined when the flag was not provided */
+  value?: boolean;
+  error?: string;
+}
+
+/**
+ * Parses a comma-separated `return` query value into supported expansion tokens.
+ */
+export function parseReturnSelector(raw: string | undefined): ReturnSelectorParseResult {
+  if (!raw || !raw.trim()) {
+    return { valid: true, fields: [] };
+  }
+
+  const parts = raw.split(',').map((part) => part.trim()).filter(Boolean);
+  const fields: ReturnField[] = [];
+  const seen = new Set<ReturnField>();
+
+  for (const part of parts) {
+    if (!RETURN_FIELD_TOKENS.includes(part as ReturnField)) {
+      return {
+        valid: false,
+        fields: [],
+        error: `Unknown return field: ${part}. Supported: ${RETURN_FIELD_TOKENS.join(', ')}`,
+      };
+    }
+
+    const token = part as ReturnField;
+    if (!seen.has(token)) {
+      seen.add(token);
+      fields.push(token);
+    }
+  }
+
+  return { valid: true, fields };
+}
+
+/**
+ * Parses the separate `include_province` flag.
+ */
+export function parseIncludeProvince(raw: string | undefined): IncludeProvinceParseResult {
+  if (raw === undefined || !raw.trim()) {
+    return { valid: true, value: undefined };
+  }
+
+  const normalized = raw.trim().toLowerCase();
+  if (normalized === 'true' || normalized === '1' || normalized === 'yes') {
+    return { valid: true, value: true };
+  }
+  if (normalized === 'false' || normalized === '0' || normalized === 'no') {
+    return { valid: true, value: false };
+  }
+
+  return {
+    valid: false,
+    error: 'include_province must be true or false',
+  };
+}
+
+/**
+ * Resolves whether provincial data should be included for this request.
+ * `/api/combined` defaults to true unless explicitly set to false.
+ */
+export function resolveIncludeProvince(
+  pathname: string,
+  includeProvince?: boolean
+): boolean {
+  if (includeProvince !== undefined) {
+    return includeProvince;
+  }
+  return pathname === '/api/combined';
+}
+
+export function isFederalLookupPath(pathname: string): boolean {
+  return pathname === '/api' || pathname === '/api/federal' || pathname === '/api/combined';
+}
+
+export function wantsReturnField(fields: ReturnField[], field: ReturnField): boolean {
+  return fields.includes(field);
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -222,7 +222,12 @@ export interface GeoJSONFeatureCollection {
 }
 
 // Query and result interfaces
-export type ReturnField = 'municipality';
+import type { ReturnField } from './return-selector';
+export type { ReturnField };
+
+export type CircuitBreakerExecutor = {
+  execute: (key: string, fn: () => Promise<unknown>) => Promise<unknown>;
+};
 
 export interface QueryParams {
   address?: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -222,6 +222,8 @@ export interface GeoJSONFeatureCollection {
 }
 
 // Query and result interfaces
+export type ReturnField = 'municipality';
+
 export interface QueryParams {
   address?: string;
   postal?: string;
@@ -230,6 +232,14 @@ export interface QueryParams {
   city?: string;
   state?: string; // province/state
   country?: string;
+  /** Raw comma-separated return selector from query string or batch body */
+  return?: string;
+  /** Parsed return fields (set during validation) */
+  returnFields?: ReturnField[];
+  /** Raw include_province flag from query string or batch body */
+  include_province?: string;
+  /** Parsed include_province flag (set during validation) */
+  includeProvince?: boolean;
 }
 
 export interface LookupResult {
@@ -272,6 +282,7 @@ export interface BatchLookupResponse {
   properties: Record<string, unknown> | null;
   riding?: string;
   province_data?: { riding: string; properties: Record<string, unknown>; dataset: string } | null;
+  municipality?: string;
   normalizedAddress?: string;
   addressComponents?: GoogleAddressComponents;
   error?: string;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,6 @@
-import { Env, QueryParams, GeoJSONGeometry } from './types';
+import { Env, QueryParams, GeoJSONGeometry, ReturnField } from './types';
 import { TIMEOUT_CONFIG, RETRY_CONFIG, getRetryConfig } from './config';
+import { parseReturnSelector, parseIncludeProvince, resolveIncludeProvince } from './return-selector';
 
 // Re-export for backward compatibility
 export const DEFAULT_TIMEOUTS = TIMEOUT_CONFIG;
@@ -286,6 +287,24 @@ export function validateAndSanitizeQuery(query: QueryParams): ValidationResult {
     sanitized.lat = coordValidation.lat;
     sanitized.lon = coordValidation.lon;
   }
+
+  if (query.return !== undefined) {
+    const returnParse = parseReturnSelector(query.return);
+    if (!returnParse.valid) {
+      return { valid: false, error: returnParse.error };
+    }
+    sanitized.return = query.return;
+    sanitized.returnFields = returnParse.fields;
+  }
+
+  if (query.include_province !== undefined) {
+    const includeProvinceParse = parseIncludeProvince(query.include_province);
+    if (!includeProvinceParse.valid) {
+      return { valid: false, error: includeProvinceParse.error };
+    }
+    sanitized.include_province = query.include_province;
+    sanitized.includeProvince = includeProvinceParse.value;
+  }
   
   // Check that at least one location parameter is provided
   const hasLocation = sanitized.address || sanitized.postal || sanitized.city || 
@@ -472,6 +491,14 @@ const PROV_TERR_TO_PROVINCE_PATH: Record<string, "/api/on" | "/api/qc"> = {
   QUEBEC: "/api/qc",
 };
 
+export function resolveQueryReturnFields(query: QueryParams): ReturnField[] {
+  return query.returnFields ?? [];
+}
+
+export function resolveQueryIncludeProvince(pathname: string, query: QueryParams): boolean {
+  return resolveIncludeProvince(pathname, query.includeProvince);
+}
+
 /**
  * Maps federal feature PROV_TERR (abbreviation or full name, EN/FR) to a provincial lookup path.
  */
@@ -501,6 +528,8 @@ export function parseQuery(request: Request): { query: QueryParams; validation: 
     city: q.get("city") || undefined,
     state: q.get("state") || q.get("province") || undefined,
     country: q.get("country") || undefined,
+    return: q.get("return") || undefined,
+    include_province: q.get("include_province") || undefined,
     lat: q.get("lat") ? Number(q.get("lat")) : undefined,
     lon: q.get("lon") || q.get("lng") || q.get("long") ? Number(q.get("lon") || q.get("lng") || q.get("long")) : undefined
   };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,4 @@
-import { Env, QueryParams, GeoJSONGeometry, ReturnField } from './types';
+import { Env, QueryParams, GeoJSONGeometry } from './types';
 import { TIMEOUT_CONFIG, RETRY_CONFIG, getRetryConfig } from './config';
 import { parseReturnSelector, parseIncludeProvince, resolveIncludeProvince } from './return-selector';
 
@@ -260,7 +260,7 @@ export function validatePostalCode(postal: string): { valid: boolean; sanitized?
  * @param query - Raw query parameters from request
  * @returns Validation result with sanitized parameters or error message
  */
-export function validateAndSanitizeQuery(query: QueryParams): ValidationResult {
+export function validateAndSanitizeQuery(query: QueryParams, pathname: string): ValidationResult {
   const sanitized: QueryParams = {};
   
   // Sanitize string inputs
@@ -305,6 +305,9 @@ export function validateAndSanitizeQuery(query: QueryParams): ValidationResult {
     sanitized.include_province = query.include_province;
     sanitized.includeProvince = includeProvinceParse.value;
   }
+
+  sanitized.returnFields = sanitized.returnFields ?? [];
+  sanitized.includeProvince = resolveIncludeProvince(pathname, sanitized.includeProvince);
   
   // Check that at least one location parameter is provided
   const hasLocation = sanitized.address || sanitized.postal || sanitized.city || 
@@ -491,14 +494,6 @@ const PROV_TERR_TO_PROVINCE_PATH: Record<string, "/api/on" | "/api/qc"> = {
   QUEBEC: "/api/qc",
 };
 
-export function resolveQueryReturnFields(query: QueryParams): ReturnField[] {
-  return query.returnFields ?? [];
-}
-
-export function resolveQueryIncludeProvince(pathname: string, query: QueryParams): boolean {
-  return resolveIncludeProvince(pathname, query.includeProvince);
-}
-
 /**
  * Maps federal feature PROV_TERR (abbreviation or full name, EN/FR) to a provincial lookup path.
  */
@@ -535,7 +530,7 @@ export function parseQuery(request: Request): { query: QueryParams; validation: 
   };
   
   // Validate and sanitize
-  const validation = validateAndSanitizeQuery(rawQuery);
+  const validation = validateAndSanitizeQuery(rawQuery, url.pathname);
   
   return { query: rawQuery, validation };
 }

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import type { BatchLookupRequest } from './types';
+import { parseReturnSelector, parseIncludeProvince, resolveIncludeProvince } from './return-selector';
 
 /**
  * Runtime type validation schemas for external API responses.
@@ -220,6 +221,8 @@ const QueryParamsSchema = z.object({
   city: z.string().optional(),
   state: z.string().optional(),
   country: z.string().optional(),
+  return: z.string().optional(),
+  include_province: z.string().optional(),
 }).refine(
   (query) =>
     (query.lat !== undefined && query.lon !== undefined) ||
@@ -237,7 +240,52 @@ export const BatchLookupRequestSchema = z.object({
 export const BatchLookupRequestsSchema = z.array(BatchLookupRequestSchema).min(1).max(100);
 
 export function parseBatchLookupRequests(data: unknown): BatchLookupRequest[] {
-  return BatchLookupRequestsSchema.parse(data) as BatchLookupRequest[];
+  const parsed = BatchLookupRequestsSchema.parse(data) as BatchLookupRequest[];
+  return enrichBatchLookupRequests(parsed);
+}
+
+function enrichBatchLookupRequests(requests: BatchLookupRequest[]): BatchLookupRequest[] {
+  return requests.map((request) => {
+    let returnFields = request.query.returnFields;
+    let includeProvince = request.query.includeProvince;
+
+    if (request.query.return !== undefined) {
+      const returnParse = parseReturnSelector(request.query.return);
+      if (!returnParse.valid) {
+        throw new z.ZodError([
+          {
+            code: 'custom',
+            message: returnParse.error ?? 'Invalid return selector',
+            path: ['query', 'return'],
+          },
+        ]);
+      }
+      returnFields = returnParse.fields;
+    }
+
+    if (request.query.include_province !== undefined) {
+      const includeProvinceParse = parseIncludeProvince(request.query.include_province);
+      if (!includeProvinceParse.valid) {
+        throw new z.ZodError([
+          {
+            code: 'custom',
+            message: includeProvinceParse.error ?? 'Invalid include_province flag',
+            path: ['query', 'include_province'],
+          },
+        ]);
+      }
+      includeProvince = includeProvinceParse.value;
+    }
+
+    return {
+      ...request,
+      query: {
+        ...request.query,
+        returnFields: returnFields ?? [],
+        includeProvince: resolveIncludeProvince(request.pathname, includeProvince),
+      },
+    };
+  });
 }
 
 export function safeParseBatchLookupRequests(
@@ -245,7 +293,17 @@ export function safeParseBatchLookupRequests(
 ): { success: true; data: BatchLookupRequest[] } | { success: false; error: z.ZodError } {
   const result = BatchLookupRequestsSchema.safeParse(data);
   if (result.success) {
-    return { success: true, data: result.data as BatchLookupRequest[] };
+    try {
+      return {
+        success: true,
+        data: enrichBatchLookupRequests(result.data as BatchLookupRequest[]),
+      };
+    } catch (error) {
+      if (error instanceof z.ZodError) {
+        return { success: false, error };
+      }
+      throw error;
+    }
   }
   return { success: false, error: result.error };
 }

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -19,8 +19,7 @@ import {
   performCacheWarming,
   getCacheWarmingStatus,
   generateLookupCacheKey,
-  getCachedLookupResult,
-  setCachedLookupResult
+  getCachedLookupResult
 } from './cache';
 import { initializeCircuitBreakers, geocodingCircuitBreaker, r2CircuitBreaker } from './circuit-breaker';
 import { incrementMetric, recordTiming, getMetrics, getMetricsSummary } from './metrics';
@@ -28,8 +27,7 @@ import {
   isPointInPolygon, 
   withTimeout, 
   withRetry, 
-  pickDataset,
-  provincePathFromFederalProperties,
+  pickDataset, 
   parseQuery, 
   checkBasicAuth,
   checkAdminAuth, 
@@ -38,8 +36,11 @@ import {
   rateLimitExceededResponse,
   checkRateLimit,
   getClientId,
-  getCorrelationId
+  getCorrelationId,
+  resolveQueryReturnFields,
+  resolveQueryIncludeProvince
 } from './utils';
+import { performExpandedLookup, type NormalizedAddressContext } from './lookup-expansion';
 import { 
   createSpatialIndex, 
   findCandidateFeatures, 
@@ -1177,224 +1178,135 @@ export default {
           const timeoutConfig = getTimeoutConfig(env);
           const cb = geocodingCircuitBreaker ? { execute: (k: string, fn: () => Promise<unknown>) => geocodingCircuitBreaker!.execute(k, fn) } : undefined;
 
-          // Combined endpoint: federal + optional ON/QC provincial lookup
-          if (lookupPathname === '/api/combined') {
-            const federalPath = FEDERAL_PATH;
-            const federalCacheKey = generateLookupCacheKey(sanitizedQuery, federalPath);
-            const federalCached = await getCachedLookupResult(env, federalCacheKey);
-            if (federalCached) {
-              incrementMetric('lookupCacheHits');
-            }
-
-            let point = federalCached?.point || (sanitizedQuery.lat !== undefined && sanitizedQuery.lon !== undefined
-              ? { lon: sanitizedQuery.lon, lat: sanitizedQuery.lat }
-              : undefined);
-
-            let normalizedAddress: string | undefined;
-            let addressComponents: LookupResult['addressComponents'];
-
-            if (!point) {
-              const geocodeResult = await withTimeout(
-                geocodeIfNeeded(env, sanitizedQuery, request, undefined, cb),
-                timeoutConfig.geocoding,
-                "Geocoding"
-              );
-              point = { lon: geocodeResult.lon, lat: geocodeResult.lat };
-              normalizedAddress = geocodeResult.normalizedAddress;
-              addressComponents = geocodeResult.addressComponents;
-              if (!isOdaEnabled(env) && (request?.headers.get('X-Google-API-Key') || env.GOOGLE_MAPS_KEY)) {
-                const googleResult = await normalizeAddressWithGoogle(env, geocodeResult.lat, geocodeResult.lon, request, cb);
-                if (googleResult) {
-                  normalizedAddress = googleResult.formattedAddress;
-                  addressComponents = googleResult.components;
-                }
-              } else if (isOdaEnabled(env)) {
-                const odaNorm = await resolveNormalizedAddress(env, geocodeResult.lat, geocodeResult.lon, sanitizedQuery, request, cb);
-                if (odaNorm) {
-                  normalizedAddress = odaNorm.normalizedAddress;
-                  addressComponents = odaNorm.addressComponents;
-                }
-              }
-            }
-
-            const { lon, lat } = point;
-
-            let federalResult: LookupResult;
-            if (federalCached) {
-              federalResult = {
-                properties: federalCached.properties || {},
-                riding: federalCached.riding,
-                ...(federalCached.normalizedAddress && { normalizedAddress: federalCached.normalizedAddress }),
-                ...(federalCached.addressComponents && { addressComponents: federalCached.addressComponents })
-              };
-            } else {
-              incrementMetric('lookupCacheMisses');
-              const fedLookup = await withTimeout(
-                lookupRiding(env, federalPath, lon, lat),
-                timeoutConfig.lookup,
-                "Riding lookup"
-              );
-              federalResult = { properties: fedLookup.properties, riding: fedLookup.riding };
-              if (normalizedAddress) federalResult.normalizedAddress = normalizedAddress;
-              if (addressComponents) federalResult.addressComponents = addressComponents;
-              const { r2Key } = pickDataset(federalPath);
-              const dataset = r2Key.replace('.geojson', '');
-              await setCachedLookupResult(env, federalCacheKey, federalResult, dataset, { lon, lat });
-            }
-
-            const provincePath = provincePathFromFederalProperties(federalResult.properties as Record<string, unknown> | null);
-
-            let provinceData: { riding: string; properties: Record<string, unknown>; dataset: string } | null = null;
-            let provinceCachedHit = false;
-
-            if (provincePath) {
-              const provinceCacheKey = generateLookupCacheKey(sanitizedQuery, provincePath);
-              const cachedProv = await getCachedLookupResult(env, provinceCacheKey);
-              if (cachedProv) {
-                incrementMetric('lookupCacheHits');
-                provinceCachedHit = true;
-                provinceData = {
-                  riding: cachedProv.riding ?? '',
-                  properties: (cachedProv.properties || {}) as Record<string, unknown>,
-                  dataset: pickDataset(provincePath).r2Key.replace('.geojson', '')
-                };
-              } else {
-                incrementMetric('lookupCacheMisses');
-                try {
-                  const provLookup = await withTimeout(
-                    lookupRiding(env, provincePath, lon, lat),
-                    timeoutConfig.lookup,
-                    "Riding lookup (province)"
-                  );
-                  const { r2Key } = pickDataset(provincePath);
-                  const dataset = r2Key.replace('.geojson', '');
-                  const lookupResult: LookupResult = { properties: provLookup.properties, riding: provLookup.riding };
-                  await setCachedLookupResult(env, provinceCacheKey, lookupResult, dataset, { lon, lat });
-                  provinceData = {
-                    riding: lookupResult.riding ?? '',
-                    properties: (lookupResult.properties || {}) as Record<string, unknown>,
-                    dataset
-                  };
-                } catch (provError) {
-                  console.warn(`[${correlationId}] Provincial lookup failed (${provincePath}):`, provError instanceof Error ? provError.message : provError);
-                  provinceData = null;
-                }
-              }
-            }
-
-            recordTiming('totalLookupTime', Date.now() - startTime);
-
-            let cacheStatus: 'HIT' | 'MISS' | 'PARTIAL' = 'MISS';
-            const federalHit = !!federalCached;
-            const provinceHit = provinceCachedHit;
-            if (federalHit && (provincePath ? provinceHit : true)) {
-              cacheStatus = 'HIT';
-            } else if (federalHit || provinceHit) {
-              cacheStatus = 'PARTIAL';
-            }
-
-            return new Response(JSON.stringify({
-              query: sanitizedQuery,
-              point: { lon, lat },
-              riding: federalResult.riding,
-              properties: federalResult.properties,
-              province_data: provinceData,
-              ...(federalResult.normalizedAddress && { normalizedAddress: federalResult.normalizedAddress }),
-              ...(federalResult.addressComponents && { addressComponents: federalResult.addressComponents }),
-              correlationId
-            }), {
-              headers: {
-                "content-type": "application/json; charset=UTF-8",
-                "X-Cache-Status": cacheStatus,
-                ...getCorsHeaders(origin)
-              }
-            });
-          }
-
-          const cacheKey = generateLookupCacheKey(sanitizedQuery, lookupPathname);
-          
-          // Check lookup cache
+          const returnFields = resolveQueryReturnFields(sanitizedQuery);
+          const includeProvince = resolveQueryIncludeProvince(lookupPathname, sanitizedQuery);
+          const basePath =
+            lookupPathname === '/api' || lookupPathname === '/api/combined'
+              ? FEDERAL_PATH
+              : lookupPathname;
+          const cacheKey = generateLookupCacheKey(sanitizedQuery, basePath);
           const cachedResult = await getCachedLookupResult(env, cacheKey);
           if (cachedResult) {
             incrementMetric('lookupCacheHits');
-            recordTiming('totalLookupTime', Date.now() - startTime);
-            // Use point from cache entry if available, otherwise fall back to sanitizedQuery
-            const point = cachedResult.point || (sanitizedQuery.lat !== undefined && sanitizedQuery.lon !== undefined 
-              ? { lon: sanitizedQuery.lon, lat: sanitizedQuery.lat } 
-              : undefined);
-            return new Response(JSON.stringify({
-              query: sanitizedQuery,
-              point,
-              properties: cachedResult.properties,
-              riding: cachedResult.riding,
-              ...(cachedResult.normalizedAddress && { normalizedAddress: cachedResult.normalizedAddress }),
-              ...(cachedResult.addressComponents && { addressComponents: cachedResult.addressComponents }),
-              correlationId
-            }), {
-              headers: { 
-                "content-type": "application/json; charset=UTF-8",
-                "X-Cache-Status": "HIT",
-                ...getCorsHeaders(origin)
+          }
+
+          let lon: number;
+          let lat: number;
+          let addressContext: NormalizedAddressContext | undefined;
+
+          if (cachedResult?.point) {
+            lon = cachedResult.point.lon;
+            lat = cachedResult.point.lat;
+          } else if (
+            sanitizedQuery.lat !== undefined &&
+            sanitizedQuery.lon !== undefined
+          ) {
+            lon = sanitizedQuery.lon;
+            lat = sanitizedQuery.lat;
+          } else {
+            const geocodeResult = await withTimeout(
+              geocodeIfNeeded(env, sanitizedQuery, request, undefined, cb),
+              timeoutConfig.geocoding,
+              "Geocoding"
+            );
+            lon = geocodeResult.lon;
+            lat = geocodeResult.lat;
+            addressContext = {
+              normalizedAddress: geocodeResult.normalizedAddress,
+              addressComponents: geocodeResult.addressComponents,
+              mailingAddress: geocodeResult.mailingAddress,
+            };
+
+            if (
+              !isOdaEnabled(env) &&
+              (request?.headers.get('X-Google-API-Key') || env.GOOGLE_MAPS_KEY)
+            ) {
+              const googleResult = await normalizeAddressWithGoogle(
+                env,
+                geocodeResult.lat,
+                geocodeResult.lon,
+                request,
+                cb
+              );
+              if (googleResult) {
+                addressContext = {
+                  normalizedAddress: googleResult.formattedAddress,
+                  addressComponents: googleResult.components,
+                };
               }
-            });
-          }
-          
-          incrementMetric('lookupCacheMisses');
-          
-          const geocodeResult = await withTimeout(
-            geocodeIfNeeded(env, sanitizedQuery, request, undefined, cb),
-            timeoutConfig.geocoding,
-            "Geocoding"
-          );
-          const { lon, lat } = geocodeResult;
-          let normalizedAddress = geocodeResult.normalizedAddress;
-          let addressComponents = geocodeResult.addressComponents;
-          
-          if (!isOdaEnabled(env) && (request?.headers.get('X-Google-API-Key') || env.GOOGLE_MAPS_KEY)) {
-            const googleResult = await normalizeAddressWithGoogle(env, geocodeResult.lat, geocodeResult.lon, request, cb);
-            if (googleResult) {
-              normalizedAddress = googleResult.formattedAddress;
-              addressComponents = googleResult.components;
-            }
-          } else if (isOdaEnabled(env) && !normalizedAddress) {
-            const odaNorm = await resolveNormalizedAddress(env, lat, lon, sanitizedQuery, request, cb);
-            if (odaNorm) {
-              normalizedAddress = odaNorm.normalizedAddress;
-              addressComponents = odaNorm.addressComponents;
+            } else if (isOdaEnabled(env) && !addressContext.normalizedAddress) {
+              const odaNorm = await resolveNormalizedAddress(
+                env,
+                lat,
+                lon,
+                sanitizedQuery,
+                request,
+                cb
+              );
+              if (odaNorm) {
+                addressContext = {
+                  normalizedAddress: odaNorm.normalizedAddress,
+                  addressComponents: odaNorm.addressComponents,
+                  mailingAddress: odaNorm.mailingAddress,
+                };
+              }
             }
           }
-          
-          const result = await withTimeout(
-            lookupRiding(env, lookupPathname, lon, lat),
-            timeoutConfig.lookup,
-            "Riding lookup"
+
+          const expanded = await performExpandedLookup(
+            env,
+            lookupPathname,
+            sanitizedQuery,
+            returnFields,
+            includeProvince,
+            lookupRiding,
+            {
+              lon,
+              lat,
+              request,
+              circuitBreaker: cb,
+              timeoutConfig,
+              addressContext,
+              preloadedResult: cachedResult
+                ? {
+                    properties: cachedResult.properties,
+                    riding: cachedResult.riding,
+                    normalizedAddress: cachedResult.normalizedAddress,
+                    addressComponents: cachedResult.addressComponents,
+                  }
+                : undefined,
+              preloadedCacheStatus: cachedResult ? 'HIT' : undefined,
+            }
           );
-          
-          const { r2Key } = pickDataset(lookupPathname);
-          const dataset = r2Key.replace('.geojson', '');
-          const lookupResult: LookupResult = {
-            properties: result.properties,
-            riding: result.riding,
-            ...(normalizedAddress && { normalizedAddress }),
-            ...(addressComponents && { addressComponents })
-          };
-          await setCachedLookupResult(env, cacheKey, lookupResult, dataset, { lon, lat });
-          
+
           recordTiming('totalLookupTime', Date.now() - startTime);
-          return new Response(JSON.stringify({
-            query: sanitizedQuery,
-            point: { lon, lat },
-            ...result,
-            ...(normalizedAddress && { normalizedAddress }),
-            ...(addressComponents && { addressComponents }),
-            correlationId
-          }), {
-            headers: { 
-              "content-type": "application/json; charset=UTF-8",
-              "X-Cache-Status": "MISS",
-              ...getCorsHeaders(origin)
+
+          return new Response(
+            JSON.stringify({
+              query: sanitizedQuery,
+              point: { lon, lat },
+              riding: expanded.riding,
+              properties: expanded.properties,
+              ...(expanded.province_data !== undefined && {
+                province_data: expanded.province_data,
+              }),
+              ...(expanded.municipality && { municipality: expanded.municipality }),
+              ...(expanded.normalizedAddress && {
+                normalizedAddress: expanded.normalizedAddress,
+              }),
+              ...(expanded.addressComponents && {
+                addressComponents: expanded.addressComponents,
+              }),
+              correlationId,
+            }),
+            {
+              headers: {
+                "content-type": "application/json; charset=UTF-8",
+                "X-Cache-Status": expanded.cacheStatus,
+                ...getCorsHeaders(origin),
+              },
             }
-          });
+          );
         } catch (error) {
           incrementMetric('errorCount');
           console.error(`[${correlationId}] Lookup error:`, error);

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -1,16 +1,14 @@
 /// <reference types="@cloudflare/workers-types" />
 
 import { Env, LookupResult, GeoJSONFeatureCollection, SpatialIndex, GeoJSONFeature } from './types';
-import { geocodeIfNeeded, geocodeBatch, normalizeAddressWithGoogle } from './geocoding';
+import { geocodeIfNeeded, geocodeBatch } from './geocoding';
 import {
   handleGeocodeRoute,
   handleReverseRoute,
   handleNormalizeAddressRoute,
   handleOdaInit,
   handleOdaStats,
-  resolveNormalizedAddress,
 } from './oda-handlers';
-import { isOdaEnabled } from './oda-config';
 import { 
   geoCacheLRU, 
   spatialIndexCacheLRU, 
@@ -18,8 +16,6 @@ import {
   setCachedSpatialIndex,
   performCacheWarming,
   getCacheWarmingStatus,
-  generateLookupCacheKey,
-  getCachedLookupResult
 } from './cache';
 import { initializeCircuitBreakers, geocodingCircuitBreaker, r2CircuitBreaker } from './circuit-breaker';
 import { incrementMetric, recordTiming, getMetrics, getMetricsSummary } from './metrics';
@@ -28,7 +24,6 @@ import {
   withTimeout, 
   withRetry, 
   pickDataset, 
-  parseQuery, 
   checkBasicAuth,
   checkAdminAuth, 
   badRequest, 
@@ -37,10 +32,9 @@ import {
   checkRateLimit,
   getClientId,
   getCorrelationId,
-  resolveQueryReturnFields,
-  resolveQueryIncludeProvince
 } from './utils';
-import { performExpandedLookup, type NormalizedAddressContext } from './lookup-expansion';
+import { handleLookupRequest } from './lookup-handler';
+import { resolveLookupPath } from './return-selector';
 import { 
   createSpatialIndex, 
   findCandidateFeatures, 
@@ -73,13 +67,6 @@ import { createLandingPage, createSwaggerUI, createOpenAPISpec } from './docs';
 import { getTimeoutConfig, getRetryConfig, TIME_CONSTANTS } from './config';
 
 // Global state
-
-const FEDERAL_PATH = "/api/federal";
-
-function normalizeLookupPathname(pathname: string): string {
-  if (pathname === "/api") return FEDERAL_PATH;
-  return pathname;
-}
 
 /**
  * Handle scheduled events (Cron Triggers) for cache warming.
@@ -625,7 +612,7 @@ export default {
           }
           
           try {
-            const result = await lookupRiding(env, FEDERAL_PATH, lon, lat);
+            const result = await lookupRiding(env, resolveLookupPath('/api').datasetPath, lon, lat);
             return new Response(JSON.stringify(result), {
               headers: { 
                 "content-type": "application/json; charset=UTF-8",
@@ -1147,176 +1134,24 @@ export default {
 
       // Main lookup endpoint
       if (pathname.startsWith('/api')) {
-        const lookupPathname = normalizeLookupPathname(pathname);
-
-        // Check rate limiting
         const clientId = getClientId(request);
         if (!checkRateLimit(env, clientId)) {
           return rateLimitExceededResponse(correlationId);
         }
-        
-        // Check basic authentication for API routes (BYOK allowed)
+
         if (!checkBasicAuth(request, env)) {
           return unauthorizedResponse(correlationId);
         }
-        
-        try {
-          const { validation } = parseQuery(request);
-          
-          // Check validation result
-          if (!validation.valid) {
-            return badRequest(validation.error || "Invalid query parameters", 400, "INVALID_QUERY", correlationId);
-          }
-          
-          // Use sanitized query parameters
-          const sanitizedQuery = validation.sanitized!;
-          const origin = request.headers.get('Origin');
-          
-          // Increment lookup requests metric (before cache check)
-          incrementMetric('lookupRequests');
 
-          const timeoutConfig = getTimeoutConfig(env);
-          const cb = geocodingCircuitBreaker ? { execute: (k: string, fn: () => Promise<unknown>) => geocodingCircuitBreaker!.execute(k, fn) } : undefined;
-
-          const returnFields = resolveQueryReturnFields(sanitizedQuery);
-          const includeProvince = resolveQueryIncludeProvince(lookupPathname, sanitizedQuery);
-          const basePath =
-            lookupPathname === '/api' || lookupPathname === '/api/combined'
-              ? FEDERAL_PATH
-              : lookupPathname;
-          const cacheKey = generateLookupCacheKey(sanitizedQuery, basePath);
-          const cachedResult = await getCachedLookupResult(env, cacheKey);
-          if (cachedResult) {
-            incrementMetric('lookupCacheHits');
-          }
-
-          let lon: number;
-          let lat: number;
-          let addressContext: NormalizedAddressContext | undefined;
-
-          if (cachedResult?.point) {
-            lon = cachedResult.point.lon;
-            lat = cachedResult.point.lat;
-          } else if (
-            sanitizedQuery.lat !== undefined &&
-            sanitizedQuery.lon !== undefined
-          ) {
-            lon = sanitizedQuery.lon;
-            lat = sanitizedQuery.lat;
-          } else {
-            const geocodeResult = await withTimeout(
-              geocodeIfNeeded(env, sanitizedQuery, request, undefined, cb),
-              timeoutConfig.geocoding,
-              "Geocoding"
-            );
-            lon = geocodeResult.lon;
-            lat = geocodeResult.lat;
-            addressContext = {
-              normalizedAddress: geocodeResult.normalizedAddress,
-              addressComponents: geocodeResult.addressComponents,
-              mailingAddress: geocodeResult.mailingAddress,
-            };
-
-            if (
-              !isOdaEnabled(env) &&
-              (request?.headers.get('X-Google-API-Key') || env.GOOGLE_MAPS_KEY)
-            ) {
-              const googleResult = await normalizeAddressWithGoogle(
-                env,
-                geocodeResult.lat,
-                geocodeResult.lon,
-                request,
-                cb
-              );
-              if (googleResult) {
-                addressContext = {
-                  normalizedAddress: googleResult.formattedAddress,
-                  addressComponents: googleResult.components,
-                };
-              }
-            } else if (isOdaEnabled(env) && !addressContext.normalizedAddress) {
-              const odaNorm = await resolveNormalizedAddress(
-                env,
-                lat,
-                lon,
-                sanitizedQuery,
-                request,
-                cb
-              );
-              if (odaNorm) {
-                addressContext = {
-                  normalizedAddress: odaNorm.normalizedAddress,
-                  addressComponents: odaNorm.addressComponents,
-                  mailingAddress: odaNorm.mailingAddress,
-                };
-              }
-            }
-          }
-
-          const expanded = await performExpandedLookup(
-            env,
-            lookupPathname,
-            sanitizedQuery,
-            returnFields,
-            includeProvince,
-            lookupRiding,
-            {
-              lon,
-              lat,
-              request,
-              circuitBreaker: cb,
-              timeoutConfig,
-              addressContext,
-              preloadedResult: cachedResult
-                ? {
-                    properties: cachedResult.properties,
-                    riding: cachedResult.riding,
-                    normalizedAddress: cachedResult.normalizedAddress,
-                    addressComponents: cachedResult.addressComponents,
-                  }
-                : undefined,
-              preloadedCacheStatus: cachedResult ? 'HIT' : undefined,
-            }
-          );
-
-          recordTiming('totalLookupTime', Date.now() - startTime);
-
-          return new Response(
-            JSON.stringify({
-              query: sanitizedQuery,
-              point: { lon, lat },
-              riding: expanded.riding,
-              properties: expanded.properties,
-              ...(expanded.province_data !== undefined && {
-                province_data: expanded.province_data,
-              }),
-              ...(expanded.municipality && { municipality: expanded.municipality }),
-              ...(expanded.normalizedAddress && {
-                normalizedAddress: expanded.normalizedAddress,
-              }),
-              ...(expanded.addressComponents && {
-                addressComponents: expanded.addressComponents,
-              }),
-              correlationId,
-            }),
-            {
-              headers: {
-                "content-type": "application/json; charset=UTF-8",
-                "X-Cache-Status": expanded.cacheStatus,
-                ...getCorsHeaders(origin),
-              },
-            }
-          );
-        } catch (error) {
-          incrementMetric('errorCount');
-          console.error(`[${correlationId}] Lookup error:`, error);
-          return badRequest(
-            error instanceof Error ? error.message : "Lookup failed",
-            500,
-            "LOOKUP_ERROR",
-            correlationId
-          );
-        }
+        return handleLookupRequest(
+          request,
+          env,
+          pathname,
+          lookupRiding,
+          correlationId,
+          startTime,
+          getCorsHeaders
+        );
       }
       
       return badRequest("Not found", 404, "NOT_FOUND", correlationId)

--- a/test/lookup-expansion.test.ts
+++ b/test/lookup-expansion.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect } from 'vitest';
+import {
+  extractMunicipality,
+  applyMunicipalityToProperties,
+  buildExpandedLookupPayload,
+} from '../src/lookup-expansion';
+
+describe('extractMunicipality', () => {
+  it('prefers ODA mailing address municipality', () => {
+    expect(
+      extractMunicipality(
+        { locality: 'Toronto' },
+        { municipality: 'TORONTO', line1: '123 MAIN ST', province: 'ON', country: 'CANADA', formattedSingleLine: '', formattedMultiline: '', canadaPostCertified: false }
+      )
+    ).toBe('TORONTO');
+  });
+
+  it('falls back to Google locality', () => {
+    expect(extractMunicipality({ locality: 'Ottawa' })).toBe('Ottawa');
+  });
+
+  it('falls back to query city', () => {
+    expect(extractMunicipality(undefined, undefined, 'Toronto')).toBe('Toronto');
+  });
+});
+
+describe('applyMunicipalityToProperties', () => {
+  it('adds MUNICIPALITY without mutating source object', () => {
+    const source = { FED_NUM: '35075' };
+    const result = applyMunicipalityToProperties(source, 'TORONTO');
+    expect(result).toEqual({ FED_NUM: '35075', MUNICIPALITY: 'TORONTO' });
+    expect(source).toEqual({ FED_NUM: '35075' });
+  });
+
+  it('returns original properties when municipality is absent', () => {
+    const source = { FED_NUM: '35075' };
+    expect(applyMunicipalityToProperties(source)).toBe(source);
+  });
+});
+
+describe('buildExpandedLookupPayload', () => {
+  it('includes province_data for federal paths when include_province is true', () => {
+    const payload = buildExpandedLookupPayload(
+      { properties: { PROV_TERR: 'ON' }, riding: 'Toronto—Danforth' },
+      [],
+      '/api/federal',
+      {
+        includeProvince: true,
+        provinceData: {
+          riding: 'Beaches—East York',
+          properties: { PR_NUM: '001' },
+          dataset: 'ontarioridings-2022',
+        },
+      }
+    );
+
+    expect(payload.province_data?.riding).toBe('Beaches—East York');
+    expect(payload.municipality).toBeUndefined();
+  });
+
+  it('omits province_data when include_province is false', () => {
+    const payload = buildExpandedLookupPayload(
+      { properties: { PROV_TERR: 'ON' }, riding: 'Toronto Centre' },
+      [],
+      '/api/federal',
+      {
+        includeProvince: false,
+        provinceData: {
+          riding: 'Beaches—East York',
+          properties: { PR_NUM: '001' },
+          dataset: 'ontarioridings-2022',
+        },
+      }
+    );
+
+    expect(payload.province_data).toBeUndefined();
+  });
+
+  it('includes municipality when requested', () => {
+    const payload = buildExpandedLookupPayload(
+      { properties: { FED_NUM: '35075' }, riding: 'Toronto Centre' },
+      ['municipality'],
+      '/api/federal',
+      {
+        addressContext: {
+          mailingAddress: {
+            municipality: 'TORONTO',
+            line1: '123 MAIN ST',
+            province: 'ON',
+            country: 'CANADA',
+            formattedSingleLine: '',
+            formattedMultiline: '',
+            canadaPostCertified: false,
+          },
+        },
+      }
+    );
+
+    expect(payload.municipality).toBe('TORONTO');
+    expect(payload.properties?.MUNICIPALITY).toBe('TORONTO');
+  });
+
+  it('does not include province_data on provincial endpoints', () => {
+    const payload = buildExpandedLookupPayload(
+      { properties: { PR_NUM: '082' }, riding: 'Scarborough Southwest' },
+      [],
+      '/api/on',
+      { includeProvince: true }
+    );
+
+    expect(payload.province_data).toBeUndefined();
+  });
+});
+
+describe('OpenNorth parity fixture — 757 Victoria Park', () => {
+  /**
+   * Resolved coordinates for 757 Victoria Park Ave, Toronto (fixture).
+   * OpenNorth maps postcode to Beaches-East York; expected provincial riding is SSW.
+   */
+  const VICTORIA_PARK_COORDS = { lat: 43.6891, lon: -79.3124 };
+
+  it('documents expected provincial riding for the fixture point', () => {
+    const expectedProvincialRiding = 'Scarborough Southwest';
+    const openNorthMismatch = 'Beaches-East York';
+
+    expect(expectedProvincialRiding).not.toBe(openNorthMismatch);
+    expect(VICTORIA_PARK_COORDS.lat).toBeGreaterThan(43);
+    expect(VICTORIA_PARK_COORDS.lon).toBeLessThan(-79);
+  });
+});

--- a/test/lookup-expansion.test.ts
+++ b/test/lookup-expansion.test.ts
@@ -111,20 +111,3 @@ describe('buildExpandedLookupPayload', () => {
     expect(payload.province_data).toBeUndefined();
   });
 });
-
-describe('OpenNorth parity fixture — 757 Victoria Park', () => {
-  /**
-   * Resolved coordinates for 757 Victoria Park Ave, Toronto (fixture).
-   * OpenNorth maps postcode to Beaches-East York; expected provincial riding is SSW.
-   */
-  const VICTORIA_PARK_COORDS = { lat: 43.6891, lon: -79.3124 };
-
-  it('documents expected provincial riding for the fixture point', () => {
-    const expectedProvincialRiding = 'Scarborough Southwest';
-    const openNorthMismatch = 'Beaches-East York';
-
-    expect(expectedProvincialRiding).not.toBe(openNorthMismatch);
-    expect(VICTORIA_PARK_COORDS.lat).toBeGreaterThan(43);
-    expect(VICTORIA_PARK_COORDS.lon).toBeLessThan(-79);
-  });
-});

--- a/test/return-selector.test.ts
+++ b/test/return-selector.test.ts
@@ -3,8 +3,7 @@ import {
   parseReturnSelector,
   parseIncludeProvince,
   resolveIncludeProvince,
-  isFederalLookupPath,
-  wantsReturnField,
+  resolveLookupPath,
 } from '../src/return-selector';
 
 describe('parseReturnSelector', () => {
@@ -71,18 +70,28 @@ describe('resolveIncludeProvince', () => {
   });
 });
 
-describe('isFederalLookupPath', () => {
-  it('matches federal and combined paths', () => {
-    expect(isFederalLookupPath('/api')).toBe(true);
-    expect(isFederalLookupPath('/api/federal')).toBe(true);
-    expect(isFederalLookupPath('/api/combined')).toBe(true);
-    expect(isFederalLookupPath('/api/on')).toBe(false);
+describe('resolveLookupPath', () => {
+  it('maps /api to federal dataset path', () => {
+    expect(resolveLookupPath('/api')).toEqual({
+      lookupPathname: '/api/federal',
+      datasetPath: '/api/federal',
+      isFederal: true,
+    });
   });
-});
 
-describe('wantsReturnField', () => {
-  it('checks membership', () => {
-    expect(wantsReturnField(['municipality'], 'municipality')).toBe(true);
-    expect(wantsReturnField([], 'municipality')).toBe(false);
+  it('maps /api/combined to federal dataset with combined semantics', () => {
+    expect(resolveLookupPath('/api/combined')).toEqual({
+      lookupPathname: '/api/combined',
+      datasetPath: '/api/federal',
+      isFederal: true,
+    });
+  });
+
+  it('passes provincial paths through unchanged', () => {
+    expect(resolveLookupPath('/api/on')).toEqual({
+      lookupPathname: '/api/on',
+      datasetPath: '/api/on',
+      isFederal: false,
+    });
   });
 });

--- a/test/return-selector.test.ts
+++ b/test/return-selector.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect } from 'vitest';
+import {
+  parseReturnSelector,
+  parseIncludeProvince,
+  resolveIncludeProvince,
+  isFederalLookupPath,
+  wantsReturnField,
+} from '../src/return-selector';
+
+describe('parseReturnSelector', () => {
+  it('returns empty fields for undefined', () => {
+    expect(parseReturnSelector(undefined)).toEqual({ valid: true, fields: [] });
+  });
+
+  it('parses municipality token', () => {
+    expect(parseReturnSelector('municipality')).toEqual({
+      valid: true,
+      fields: ['municipality'],
+    });
+  });
+
+  it('rejects province_data as a return token', () => {
+    const result = parseReturnSelector('province_data');
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain('Unknown return field');
+  });
+
+  it('rejects unknown tokens', () => {
+    const result = parseReturnSelector('foo');
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain('Unknown return field');
+  });
+});
+
+describe('parseIncludeProvince', () => {
+  it('returns undefined when omitted', () => {
+    expect(parseIncludeProvince(undefined)).toEqual({ valid: true, value: undefined });
+  });
+
+  it('parses true values', () => {
+    expect(parseIncludeProvince('true').value).toBe(true);
+    expect(parseIncludeProvince('1').value).toBe(true);
+  });
+
+  it('parses false values', () => {
+    expect(parseIncludeProvince('false').value).toBe(false);
+    expect(parseIncludeProvince('0').value).toBe(false);
+  });
+
+  it('rejects invalid values', () => {
+    const result = parseIncludeProvince('maybe');
+    expect(result.valid).toBe(false);
+  });
+});
+
+describe('resolveIncludeProvince', () => {
+  it('defaults combined endpoint to true', () => {
+    expect(resolveIncludeProvince('/api/combined', undefined)).toBe(true);
+  });
+
+  it('defaults federal endpoint to false', () => {
+    expect(resolveIncludeProvince('/api/federal', undefined)).toBe(false);
+  });
+
+  it('honors explicit false on combined', () => {
+    expect(resolveIncludeProvince('/api/combined', false)).toBe(false);
+  });
+
+  it('honors explicit true on federal', () => {
+    expect(resolveIncludeProvince('/api/federal', true)).toBe(true);
+  });
+});
+
+describe('isFederalLookupPath', () => {
+  it('matches federal and combined paths', () => {
+    expect(isFederalLookupPath('/api')).toBe(true);
+    expect(isFederalLookupPath('/api/federal')).toBe(true);
+    expect(isFederalLookupPath('/api/combined')).toBe(true);
+    expect(isFederalLookupPath('/api/on')).toBe(false);
+  });
+});
+
+describe('wantsReturnField', () => {
+  it('checks membership', () => {
+    expect(wantsReturnField(['municipality'], 'municipality')).toBe(true);
+    expect(wantsReturnField([], 'municipality')).toBe(false);
+  });
+});

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -12,8 +12,6 @@ import {
   checkBasicAuth,
   checkAdminAuth,
   validateAndSanitizeQuery,
-  resolveQueryReturnFields,
-  resolveQueryIncludeProvince,
 } from '../src/utils';
 
 describe('validateCoordinates', () => {
@@ -242,28 +240,37 @@ function authRequest(headers: Record<string, string> = {}): Request {
 
 describe('validateAndSanitizeQuery return selector', () => {
   it('parses valid return tokens', () => {
-    const result = validateAndSanitizeQuery({
-      postal: 'M5V 2T6',
-      return: 'municipality',
-    });
+    const result = validateAndSanitizeQuery(
+      {
+        postal: 'M5V 2T6',
+        return: 'municipality',
+      },
+      '/api/federal'
+    );
     expect(result.valid).toBe(true);
     expect(result.sanitized?.returnFields).toEqual(['municipality']);
   });
 
   it('rejects province_data in return selector', () => {
-    const result = validateAndSanitizeQuery({
-      postal: 'M5V 2T6',
-      return: 'province_data',
-    });
+    const result = validateAndSanitizeQuery(
+      {
+        postal: 'M5V 2T6',
+        return: 'province_data',
+      },
+      '/api/federal'
+    );
     expect(result.valid).toBe(false);
     expect(result.error).toContain('Unknown return field');
   });
 
   it('rejects unknown return tokens', () => {
-    const result = validateAndSanitizeQuery({
-      postal: 'M5V 2T6',
-      return: 'invalid_token',
-    });
+    const result = validateAndSanitizeQuery(
+      {
+        postal: 'M5V 2T6',
+        return: 'invalid_token',
+      },
+      '/api/federal'
+    );
     expect(result.valid).toBe(false);
     expect(result.error).toContain('Unknown return field');
   });
@@ -271,37 +278,50 @@ describe('validateAndSanitizeQuery return selector', () => {
 
 describe('validateAndSanitizeQuery include_province', () => {
   it('parses include_province=true', () => {
-    const result = validateAndSanitizeQuery({
-      postal: 'M5V 2T6',
-      include_province: 'true',
-    });
+    const result = validateAndSanitizeQuery(
+      {
+        postal: 'M5V 2T6',
+        include_province: 'true',
+      },
+      '/api/federal'
+    );
     expect(result.valid).toBe(true);
     expect(result.sanitized?.includeProvince).toBe(true);
   });
 
   it('rejects invalid include_province values', () => {
-    const result = validateAndSanitizeQuery({
-      postal: 'M5V 2T6',
-      include_province: 'maybe',
-    });
+    const result = validateAndSanitizeQuery(
+      {
+        postal: 'M5V 2T6',
+        include_province: 'maybe',
+      },
+      '/api/federal'
+    );
     expect(result.valid).toBe(false);
   });
-});
 
-describe('resolveQueryIncludeProvince', () => {
   it('defaults province inclusion for combined endpoint', () => {
-    expect(resolveQueryIncludeProvince('/api/combined', {})).toBe(true);
+    const result = validateAndSanitizeQuery({ postal: 'M5V 2T6' }, '/api/combined');
+    expect(result.valid).toBe(true);
+    expect(result.sanitized?.includeProvince).toBe(true);
   });
 
   it('requires explicit flag on federal endpoint', () => {
-    expect(resolveQueryIncludeProvince('/api/federal', {})).toBe(false);
-    expect(resolveQueryIncludeProvince('/api/federal', { includeProvince: true })).toBe(true);
-  });
-});
+    const result = validateAndSanitizeQuery({ postal: 'M5V 2T6' }, '/api/federal');
+    expect(result.valid).toBe(true);
+    expect(result.sanitized?.includeProvince).toBe(false);
 
-describe('resolveQueryReturnFields', () => {
-  it('returns parsed return fields', () => {
-    expect(resolveQueryReturnFields({ returnFields: ['municipality'] })).toEqual(['municipality']);
+    const explicit = validateAndSanitizeQuery(
+      { postal: 'M5V 2T6', include_province: 'true' },
+      '/api/federal'
+    );
+    expect(explicit.sanitized?.includeProvince).toBe(true);
+  });
+
+  it('defaults returnFields to empty array', () => {
+    const result = validateAndSanitizeQuery({ postal: 'M5V 2T6' }, '/api/federal');
+    expect(result.valid).toBe(true);
+    expect(result.sanitized?.returnFields).toEqual([]);
   });
 });
 

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -10,7 +10,10 @@ import {
   pickDataset,
   provincePathFromFederalProperties,
   checkBasicAuth,
-  checkAdminAuth
+  checkAdminAuth,
+  validateAndSanitizeQuery,
+  resolveQueryReturnFields,
+  resolveQueryIncludeProvince,
 } from '../src/utils';
 
 describe('validateCoordinates', () => {
@@ -236,6 +239,71 @@ describe('provincePathFromFederalProperties', () => {
 function authRequest(headers: Record<string, string> = {}): Request {
   return new Request('https://example.com/api', { headers });
 }
+
+describe('validateAndSanitizeQuery return selector', () => {
+  it('parses valid return tokens', () => {
+    const result = validateAndSanitizeQuery({
+      postal: 'M5V 2T6',
+      return: 'municipality',
+    });
+    expect(result.valid).toBe(true);
+    expect(result.sanitized?.returnFields).toEqual(['municipality']);
+  });
+
+  it('rejects province_data in return selector', () => {
+    const result = validateAndSanitizeQuery({
+      postal: 'M5V 2T6',
+      return: 'province_data',
+    });
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain('Unknown return field');
+  });
+
+  it('rejects unknown return tokens', () => {
+    const result = validateAndSanitizeQuery({
+      postal: 'M5V 2T6',
+      return: 'invalid_token',
+    });
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain('Unknown return field');
+  });
+});
+
+describe('validateAndSanitizeQuery include_province', () => {
+  it('parses include_province=true', () => {
+    const result = validateAndSanitizeQuery({
+      postal: 'M5V 2T6',
+      include_province: 'true',
+    });
+    expect(result.valid).toBe(true);
+    expect(result.sanitized?.includeProvince).toBe(true);
+  });
+
+  it('rejects invalid include_province values', () => {
+    const result = validateAndSanitizeQuery({
+      postal: 'M5V 2T6',
+      include_province: 'maybe',
+    });
+    expect(result.valid).toBe(false);
+  });
+});
+
+describe('resolveQueryIncludeProvince', () => {
+  it('defaults province inclusion for combined endpoint', () => {
+    expect(resolveQueryIncludeProvince('/api/combined', {})).toBe(true);
+  });
+
+  it('requires explicit flag on federal endpoint', () => {
+    expect(resolveQueryIncludeProvince('/api/federal', {})).toBe(false);
+    expect(resolveQueryIncludeProvince('/api/federal', { includeProvince: true })).toBe(true);
+  });
+});
+
+describe('resolveQueryReturnFields', () => {
+  it('returns parsed return fields', () => {
+    expect(resolveQueryReturnFields({ returnFields: ['municipality'] })).toEqual(['municipality']);
+  });
+});
 
 describe('checkBasicAuth', () => {
   it('allows BYOK lookup access when BASIC_AUTH is configured', () => {

--- a/test/validation.test.ts
+++ b/test/validation.test.ts
@@ -53,4 +53,44 @@ describe('safeParseBatchLookupRequests', () => {
 
     expect(result.success).toBe(false);
   });
+
+  it('parses return selector on batch query objects', () => {
+    const result = safeParseBatchLookupRequests([
+      {
+        id: 'req_1',
+        pathname: '/api/combined',
+        query: { postal: 'M5V 2T6', return: 'municipality' },
+      },
+    ]);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data[0].query.returnFields).toEqual(['municipality']);
+      expect(result.data[0].query.includeProvince).toBe(true);
+    }
+  });
+
+  it('parses include_province on batch query objects', () => {
+    const result = safeParseBatchLookupRequests([
+      {
+        id: 'req_1',
+        pathname: '/api/federal',
+        query: { postal: 'M5V 2T6', include_province: 'true' },
+      },
+    ]);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data[0].query.includeProvince).toBe(true);
+    }
+  });
+
+  it('rejects unknown return selector in batch query', () => {
+    const result = safeParseBatchLookupRequests([
+      {
+        id: 'req_1',
+        pathname: '/api/federal',
+        query: { postal: 'K1A 0B1', return: 'bad_field' },
+      },
+    ]);
+    expect(result.success).toBe(false);
+  });
 });


### PR DESCRIPTION
## Summary

Adds optional provincial and municipality expansion to federal lookups, documents hosting tradeoffs, and consolidates HTTP/batch lookup into a single pipeline.

- **`/api/combined`** — federal lookup with provincial riding included by default (`include_province` can opt out)
- **`include_province`** — optional flag on `/api`, `/api/federal`, and batch requests
- **`return=municipality`** — adds `municipality` to the response and `properties.MUNICIPALITY` when address normalization is available
- **Benchmark script** — `npm run benchmark:lookup` for local performance comparison
- **Lookup refactor** — extracted `lookup-handler.ts`; `performExpandedLookup` is now the single orchestration path for HTTP and batch (deduplicated province cache, unified pathname resolution, validation-boundary defaults)

## Issues

| Issue | Relationship |
|-------|--------------|
| #4 | Addresses optional provincial data on federal lookups via `include_province` and `/api/combined` |
| #7 | Addresses municipality in response and `properties.MUNICIPALITY` via `return=municipality` |
| #8 | Adds benchmark tooling to measure lookup latency locally |
| #5 | Documents Workers vs GCP hosting decision in `docs/hosting.md` |
| #11 | Adds ODA fixture coverage for combined/province/municipality expansion (`docs/oda-fixtures.md`) |

## Test plan

- [x] `npm run typecheck`
- [x] `npm test` (198 tests)
- [ ] Manual: `GET /api/combined?postal=...` returns `province_data`
- [ ] Manual: `GET /api/federal?postal=...&include_province=true` returns `province_data`
- [ ] Manual: `GET /api/federal?postal=...&return=municipality` returns `municipality` and `properties.MUNICIPALITY`
- [ ] Manual: batch POST with `include_province` / `return` fields