### PR TITLE
Return mailing address and geocode metadata in lookup and batch responses

### DIFF
--- a/src/batch.ts
+++ b/src/batch.ts
@@ -88,7 +88,15 @@ export async function processBatchLookupWithBatchGeocoding(
     ): Promise<
       Pick<
         BatchLookupResponse,
-        'point' | 'properties' | 'riding' | 'province_data' | 'municipality' | 'normalizedAddress' | 'addressComponents'
+        | 'point'
+        | 'properties'
+        | 'riding'
+        | 'province_data'
+        | 'municipality'
+        | 'normalizedAddress'
+        | 'addressComponents'
+        | 'mailingAddress'
+        | 'geocode'
       >
     > => {
       const expanded = await performExpandedLookup(
@@ -146,6 +154,9 @@ export async function processBatchLookupWithBatchGeocoding(
             const addressContext: NormalizedAddressContext = {
               normalizedAddress: geocodingResult.normalizedAddress,
               addressComponents: geocodingResult.addressComponents,
+              mailingAddress: geocodingResult.mailingAddress,
+              geocodeMethod: geocodingResult.geocodeMethod,
+              geocodeConfidence: geocodingResult.confidence,
             };
             const payload = await runExpandedLookup(
               batchRequest,

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -549,6 +549,8 @@ export async function setCachedLookupResult(env: Env, cacheKey: string, result: 
       riding: result.riding,
       point,
       normalizedAddress: result.normalizedAddress,
+      addressComponents: result.addressComponents,
+      mailingAddress: result.mailingAddress,
       timestamp: Date.now(),
       dataset
     };

--- a/src/geocoding.ts
+++ b/src/geocoding.ts
@@ -9,6 +9,7 @@ import {
   Metrics,
   DeferTaskFn,
   CircuitBreakerExecutor,
+  CanadaPostStyleAddress,
 } from './types';
 import { getTimeoutConfig, getRetryConfig, TIME_CONSTANTS, TIME_CONSTANTS_SECONDS, QUALITY_THRESHOLDS, GEOCODING_STAGE_TIMEOUTS } from './config';
 import { withRetry, withTimeout, NonRetriableError } from './utils';
@@ -270,7 +271,30 @@ export type GeocodeResult = {
   addressComponents?: GoogleAddressComponents;
 } & OdaGeocodeMetadata;
 
-export type GeocodeBatchResult = { lon: number; lat: number; success: boolean; error?: string; normalizedAddress?: string; addressComponents?: GoogleAddressComponents };
+export type GeocodeBatchResult = {
+  lon: number;
+  lat: number;
+  success: boolean;
+  error?: string;
+  normalizedAddress?: string;
+  addressComponents?: GoogleAddressComponents;
+  mailingAddress?: CanadaPostStyleAddress;
+  geocodeMethod?: string;
+  confidence?: number;
+};
+
+function geocodeResultToBatchResult(result: GeocodeResult): GeocodeBatchResult {
+  return {
+    lon: result.lon,
+    lat: result.lat,
+    success: true,
+    normalizedAddress: result.normalizedAddress,
+    addressComponents: result.addressComponents,
+    mailingAddress: result.mailingAddress,
+    geocodeMethod: result.geocodeMethod,
+    confidence: result.confidence,
+  };
+}
 
 /**
  * Parses Google address_components array into structured address components object.
@@ -1118,6 +1142,8 @@ export async function geocodeBatch(
         success: r.success,
         error: r.error,
         normalizedAddress: r.normalizedAddress,
+        geocodeMethod: r.geocodeMethod,
+        confidence: r.confidence,
       }));
     }
   }
@@ -1138,7 +1164,7 @@ export async function geocodeBatch(
         for (const query of batch) {
           try {
             const result = await geocodeIfNeeded(env, query, request, metrics, circuitBreaker);
-            results.push({ lon: result.lon, lat: result.lat, success: true, normalizedAddress: result.normalizedAddress });
+            results.push(geocodeResultToBatchResult(result));
           } catch (error) {
             results.push({
               lon: 0,
@@ -1155,7 +1181,7 @@ export async function geocodeBatch(
       for (const query of batch) {
         try {
           const result = await geocodeIfNeeded(env, query, request, metrics, circuitBreaker);
-          results.push({ lon: result.lon, lat: result.lat, success: true, normalizedAddress: result.normalizedAddress });
+          results.push(geocodeResultToBatchResult(result));
         } catch (individualError) {
           results.push({
             lon: 0,

--- a/src/lookup-expansion.ts
+++ b/src/lookup-expansion.ts
@@ -37,6 +37,7 @@ export interface ExpandedLookupPayload {
   municipality?: string;
   normalizedAddress?: string;
   addressComponents?: GoogleAddressComponents;
+  mailingAddress?: CanadaPostStyleAddress;
   geocode?: { method: string; confidence?: number };
   cacheStatus: 'HIT' | 'MISS' | 'PARTIAL';
 }
@@ -219,6 +220,17 @@ function computeCombinedCacheStatus(
   return 'MISS';
 }
 
+function mergeAddressFields(
+  base: LookupResult,
+  addressContext: NormalizedAddressContext
+): Pick<ExpandedLookupPayload, 'normalizedAddress' | 'addressComponents' | 'mailingAddress'> {
+  return {
+    normalizedAddress: addressContext.normalizedAddress ?? base.normalizedAddress,
+    addressComponents: addressContext.addressComponents ?? base.addressComponents,
+    mailingAddress: addressContext.mailingAddress ?? base.mailingAddress,
+  };
+}
+
 export function buildExpandedLookupPayload(
   base: LookupResult,
   returnFields: readonly string[],
@@ -268,6 +280,17 @@ export function buildExpandedLookupPayload(
     payload.municipality = municipality;
   }
 
+  const addressFields = mergeAddressFields(base, addressContext);
+  if (addressFields.normalizedAddress) {
+    payload.normalizedAddress = addressFields.normalizedAddress;
+  }
+  if (addressFields.addressComponents) {
+    payload.addressComponents = addressFields.addressComponents;
+  }
+  if (addressFields.mailingAddress) {
+    payload.mailingAddress = addressFields.mailingAddress;
+  }
+
   return payload;
 }
 
@@ -279,6 +302,7 @@ export function expandedLookupResponseFields(expanded: ExpandedLookupPayload): {
   municipality?: string;
   normalizedAddress?: string;
   addressComponents?: GoogleAddressComponents;
+  mailingAddress?: CanadaPostStyleAddress;
   geocode?: { method: string; confidence?: number };
 } {
   return {
@@ -288,6 +312,7 @@ export function expandedLookupResponseFields(expanded: ExpandedLookupPayload): {
     ...(expanded.municipality && { municipality: expanded.municipality }),
     ...(expanded.normalizedAddress && { normalizedAddress: expanded.normalizedAddress }),
     ...(expanded.addressComponents && { addressComponents: expanded.addressComponents }),
+    ...(expanded.mailingAddress && { mailingAddress: expanded.mailingAddress }),
     ...(expanded.geocode && { geocode: expanded.geocode }),
   };
 }
@@ -381,6 +406,7 @@ export async function performExpandedLookup(
       riding: cached.riding,
       normalizedAddress: cached.normalizedAddress,
       addressComponents: cached.addressComponents,
+      mailingAddress: cached.mailingAddress,
     };
   } else {
     incrementMetric('lookupCacheMisses');
@@ -396,8 +422,9 @@ export async function performExpandedLookup(
         {
           properties: lookup.properties,
           riding: lookup.riding,
-          normalizedAddress: lookup.normalizedAddress,
-          addressComponents: lookup.addressComponents,
+          normalizedAddress: resolvedAddressContext?.normalizedAddress,
+          addressComponents: resolvedAddressContext?.addressComponents,
+          mailingAddress: resolvedAddressContext?.mailingAddress,
         },
         dataset,
         { lon, lat }

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -41,6 +41,9 @@ const metrics: Metrics = {
   geocodingOdaTime: 0,
   geocodingGeoGratisTime: 0,
   geocodingFallbackTime: 0,
+  odaD1Reads: 0,
+  odaD1QueriesMaxPerRequest: 0,
+  odaStageTimeouts: 0,
   totalR2Time: 0,
   totalBatchTime: 0,
   totalWebhookTime: 0
@@ -64,6 +67,13 @@ export function incrementMetric(key: keyof Metrics, value: number = 1): void {
 export function recordTiming(key: keyof Metrics, duration: number): void {
   checkAndResetMetrics();
   metrics[key] += duration;
+}
+
+export function updateOdaD1QueriesMaxPerRequest(count: number): void {
+  checkAndResetMetrics();
+  if (count > metrics.odaD1QueriesMaxPerRequest) {
+    metrics.odaD1QueriesMaxPerRequest = count;
+  }
 }
 
 export function getMetrics(): Metrics {

--- a/src/oda-config.ts
+++ b/src/oda-config.ts
@@ -28,6 +28,7 @@ export interface OdaConfig {
   nnMaxCandidates: number;
   maxReverseDistanceMeters: number;
   maxAmbiguousMatches: number;
+  maxPostalCentroidDistanceMeters: number;
   dataVersion: string;
 }
 
@@ -49,6 +50,9 @@ export function getOdaConfig(env: Env): OdaConfig {
       ODA_DEFAULTS.MAX_REVERSE_DISTANCE_METERS,
     maxAmbiguousMatches:
       parseInt(env.ODA_MAX_AMBIGUOUS_MATCHES || '', 10) || ODA_DEFAULTS.MAX_AMBIGUOUS_MATCHES,
+    maxPostalCentroidDistanceMeters:
+      parseInt(env.ODA_MAX_POSTAL_CENTROID_DISTANCE_METERS || '', 10) ||
+      ODA_DEFAULTS.MAX_POSTAL_CENTROID_DISTANCE_METERS,
     dataVersion: ODA_DEFAULTS.DATA_VERSION,
   };
 }

--- a/src/oda-d1-tracker.ts
+++ b/src/oda-d1-tracker.ts
@@ -1,0 +1,29 @@
+import { incrementMetric, updateOdaD1QueriesMaxPerRequest } from './metrics';
+
+let requestQueryCount = 0;
+let trackingEnabled = false;
+
+export function beginOdaD1QueryTracking(): void {
+  requestQueryCount = 0;
+  trackingEnabled = true;
+}
+
+export function recordOdaD1Query(): void {
+  incrementMetric('odaD1Reads');
+  if (trackingEnabled) {
+    requestQueryCount++;
+  }
+}
+
+export function endOdaD1QueryTracking(): number {
+  const count = requestQueryCount;
+  trackingEnabled = false;
+  if (count > 0) {
+    updateOdaD1QueriesMaxPerRequest(count);
+  }
+  return count;
+}
+
+export function getOdaD1QueryCountForRequest(): number {
+  return requestQueryCount;
+}

--- a/src/oda-geocoding.ts
+++ b/src/oda-geocoding.ts
@@ -338,7 +338,7 @@ async function findStreetInterpolated(
     if (nearest) return nearest as OdaAddressRow;
   }
 
-  const range = await odaQueryFirst(
+  const range = (await odaQueryFirst(
     env,
     `
     SELECT lat, lon, province, street_key FROM oda_street_ranges
@@ -348,14 +348,14 @@ async function findStreetInterpolated(
     LIMIT 1
   `,
     [...provinces, cityKey, ...streetKeys, ...orderParams]
-  );
+  )) as { lat: number; lon: number; province: string; street_key?: string } | null;
 
   if (range) {
-    const matchedStreetKey = (range as { street_key?: string }).street_key || streetKeys[0];
+    const matchedStreetKey = range.street_key || streetKeys[0];
     const matchedType = matchedStreetKey.split('|')[1] || parsed.streetType || '';
     return {
       id: 0,
-      province: range.province as string,
+      province: range.province,
       civic_number: parsed.civic || '',
       street_name: parsed.streetName,
       street_type: matchedType,
@@ -363,8 +363,8 @@ async function findStreetInterpolated(
       unit: '',
       postal_code: parsed.postal || '',
       city: parsed.city,
-      lat: range.lat as number,
-      lon: range.lon as number,
+      lat: range.lat,
+      lon: range.lon,
       full_address: '',
     };
   }

--- a/src/oda-geocoding.ts
+++ b/src/oda-geocoding.ts
@@ -23,6 +23,11 @@ import {
 } from './oda-normalize';
 import { expandStreetAddress } from './geocode-region';
 import { formatFromOdaRow } from './canada-post-format';
+import {
+  beginOdaD1QueryTracking,
+  endOdaD1QueryTracking,
+  recordOdaD1Query,
+} from './oda-d1-tracker';
 
 export class OdaGeocodeError extends Error {
   code: string;
@@ -171,6 +176,37 @@ function isStreetOnlyAmbiguous(parsed: ReturnType<typeof parseAddressQuery>): bo
   return hasStreet && !hasContext;
 }
 
+const DEFAULT_STREET_TYPES = ['', 'AVE', 'ST', 'RD', 'DR', 'BLVD', 'CRES'] as const;
+
+function streetTypeCandidates(parsed: ReturnType<typeof parseAddressQuery>): string[] {
+  return parsed.streetType ? [parsed.streetType] : [...DEFAULT_STREET_TYPES];
+}
+
+function buildStreetKeyVariants(parsed: ReturnType<typeof parseAddressQuery>): string[] {
+  return streetTypeCandidates(parsed).map((streetType) =>
+    buildStreetKey(parsed.streetName!, streetType, parsed.streetDirection || '')
+  );
+}
+
+function streetKeyOrderSql(streetKeys: string[]): { orderBy: string; orderParams: string[] } {
+  const cases = streetKeys.map((_, index) => `WHEN ? THEN ${index}`).join(' ');
+  return {
+    orderBy: `CASE street_key ${cases} ELSE ${streetKeys.length} END`,
+    orderParams: streetKeys,
+  };
+}
+
+async function odaQueryFirst(env: Env, sql: string, params: unknown[]): Promise<unknown> {
+  recordOdaD1Query();
+  return env.ODA_DB!.prepare(sql).bind(...params).first();
+}
+
+async function odaQueryAll(env: Env, sql: string, params: unknown[]): Promise<unknown[]> {
+  recordOdaD1Query();
+  const result = await env.ODA_DB!.prepare(sql).bind(...params).all();
+  return result.results || [];
+}
+
 async function findExactMatch(
   env: Env,
   searchKey: string,
@@ -183,29 +219,33 @@ async function findExactMatch(
   const normalizedUnit = normalizeUnit(unit);
 
   if (normalizedUnit) {
-    const withUnit = await env.ODA_DB.prepare(`
+    const withUnit = await odaQueryFirst(
+      env,
+      `
       SELECT id, province, civic_number, street_name, street_type, street_direction,
              unit, postal_code, city, lat, lon, full_address
       FROM oda_addresses
       WHERE search_key = ? AND province IN (${placeholders}) AND unit = ?
       LIMIT 1
-    `)
-      .bind(searchKey, ...provinces, normalizedUnit)
-      .first();
+    `,
+      [searchKey, ...provinces, normalizedUnit]
+    );
     if (withUnit) return withUnit as OdaAddressRow;
     return null;
   }
 
-  const result = await env.ODA_DB.prepare(`
+  const result = await odaQueryFirst(
+    env,
+    `
     SELECT id, province, civic_number, street_name, street_type, street_direction,
            unit, postal_code, city, lat, lon, full_address
     FROM oda_addresses
     WHERE search_key = ? AND province IN (${placeholders})
     ORDER BY CASE WHEN unit = '' OR unit IS NULL THEN 0 ELSE 1 END
     LIMIT 1
-  `)
-    .bind(searchKey, ...provinces)
-    .first();
+  `,
+    [searchKey, ...provinces]
+  );
 
   return (result as OdaAddressRow | null) ?? null;
 }
@@ -218,14 +258,16 @@ async function findPostalCentroid(
   if (!env.ODA_DB) return null;
   const placeholders = provinces.map(() => '?').join(',');
 
-  const result = await env.ODA_DB.prepare(`
+  const result = await odaQueryFirst(
+    env,
+    `
     SELECT province, postal_code, lat, lon
     FROM oda_postal_centroids
     WHERE postal_code = ? AND province IN (${placeholders})
     LIMIT 1
-  `)
-    .bind(postal, ...provinces)
-    .first();
+  `,
+    [postal, ...provinces]
+  );
 
   return result as { lat: number; lon: number; province: string; postal_code: string } | null;
 }
@@ -237,78 +279,94 @@ async function findStreetInterpolated(
 ): Promise<OdaAddressRow | null> {
   if (!env.ODA_DB || !parsed.city || !parsed.streetName) return null;
 
-  const streetTypes = parsed.streetType
-    ? [parsed.streetType]
-    : ['', 'AVE', 'ST', 'RD', 'DR', 'BLVD', 'CRES'];
+  const cityKey = buildCityKey(parsed.city, parsed.province || provinces[0]);
+  const streetKeys = buildStreetKeyVariants(parsed);
+  const streetKeyPlaceholders = streetKeys.map(() => '?').join(',');
+  const provincePlaceholders = provinces.map(() => '?').join(',');
+  const { orderBy, orderParams } = streetKeyOrderSql(streetKeys);
 
-  for (const streetType of streetTypes) {
-    const cityKey = buildCityKey(parsed.city, parsed.province || provinces[0]);
-    const streetKey = buildStreetKey(
-      parsed.streetName,
-      streetType,
-      parsed.streetDirection || ''
+  if (parsed.civicParsed?.numeric !== null && parsed.civicParsed?.numeric !== undefined) {
+    const civic = parsed.civicParsed.raw;
+    const normalizedUnit = normalizeUnit(parsed.unit);
+
+    if (normalizedUnit) {
+      const exact = await odaQueryFirst(
+        env,
+        `
+        SELECT id, province, civic_number, street_name, street_type, street_direction,
+               unit, postal_code, city, lat, lon, full_address
+        FROM oda_addresses
+        WHERE province IN (${provincePlaceholders}) AND city_key = ?
+          AND street_key IN (${streetKeyPlaceholders}) AND civic_number = ? AND unit = ?
+        ORDER BY ${orderBy}
+        LIMIT 1
+      `,
+        [...provinces, cityKey, ...streetKeys, civic, normalizedUnit, ...orderParams]
+      );
+      if (exact) return exact as OdaAddressRow;
+      return null;
+    }
+
+    const exact = await odaQueryFirst(
+      env,
+      `
+      SELECT id, province, civic_number, street_name, street_type, street_direction,
+             unit, postal_code, city, lat, lon, full_address
+      FROM oda_addresses
+      WHERE province IN (${provincePlaceholders}) AND city_key = ?
+        AND street_key IN (${streetKeyPlaceholders}) AND civic_number = ?
+      ORDER BY ${orderBy}
+      LIMIT 1
+    `,
+      [...provinces, cityKey, ...streetKeys, civic, ...orderParams]
     );
-    const placeholders = provinces.map(() => '?').join(',');
+    if (exact) return exact as OdaAddressRow;
 
-    if (parsed.civicParsed?.numeric !== null && parsed.civicParsed?.numeric !== undefined) {
-      const civic = parsed.civicParsed.raw;
-      const normalizedUnit = normalizeUnit(parsed.unit);
-      const unitClause = normalizedUnit ? ' AND unit = ?' : '';
-      const exactParams: unknown[] = [...provinces, cityKey, streetKey, civic];
-      if (normalizedUnit) exactParams.push(normalizedUnit);
-
-      const exact = await env.ODA_DB.prepare(`
+    const nearest = await odaQueryFirst(
+      env,
+      `
       SELECT id, province, civic_number, street_name, street_type, street_direction,
              unit, postal_code, city, lat, lon, full_address
       FROM oda_addresses
-      WHERE province IN (${placeholders}) AND city_key = ? AND street_key = ? AND civic_number = ?${unitClause}
+      WHERE province IN (${provincePlaceholders}) AND city_key = ?
+        AND street_key IN (${streetKeyPlaceholders})
+      ORDER BY ${orderBy}, ABS(CAST(civic_number AS INTEGER) - ?) ASC
       LIMIT 1
-    `)
-        .bind(...exactParams)
-        .first();
-      if (exact) return exact as unknown as OdaAddressRow;
+    `,
+      [...provinces, cityKey, ...streetKeys, ...orderParams, parsed.civicParsed.numeric]
+    );
+    if (nearest) return nearest as OdaAddressRow;
+  }
 
-      if (normalizedUnit) {
-        continue;
-      }
-
-      const nearest = await env.ODA_DB.prepare(`
-      SELECT id, province, civic_number, street_name, street_type, street_direction,
-             unit, postal_code, city, lat, lon, full_address
-      FROM oda_addresses
-      WHERE province IN (${placeholders}) AND city_key = ? AND street_key = ?
-      ORDER BY ABS(CAST(civic_number AS INTEGER) - ?) ASC
-      LIMIT 1
-    `)
-        .bind(...provinces, cityKey, streetKey, parsed.civicParsed.numeric)
-        .first();
-      if (nearest) return nearest as unknown as OdaAddressRow;
-    }
-
-    const range = await env.ODA_DB.prepare(`
-    SELECT lat, lon, province FROM oda_street_ranges
-    WHERE province IN (${placeholders}) AND city_key = ? AND street_key = ?
+  const range = await odaQueryFirst(
+    env,
+    `
+    SELECT lat, lon, province, street_key FROM oda_street_ranges
+    WHERE province IN (${provincePlaceholders}) AND city_key = ?
+      AND street_key IN (${streetKeyPlaceholders})
+    ORDER BY ${orderBy}
     LIMIT 1
-  `)
-      .bind(...provinces, cityKey, streetKey)
-      .first();
+  `,
+    [...provinces, cityKey, ...streetKeys, ...orderParams]
+  );
 
-    if (range) {
-      return {
-        id: 0,
-        province: range.province as string,
-        civic_number: parsed.civic || '',
-        street_name: parsed.streetName,
-        street_type: streetType || parsed.streetType || '',
-        street_direction: parsed.streetDirection || '',
-        unit: '',
-        postal_code: parsed.postal || '',
-        city: parsed.city,
-        lat: range.lat as number,
-        lon: range.lon as number,
-        full_address: '',
-      };
-    }
+  if (range) {
+    const matchedStreetKey = (range as { street_key?: string }).street_key || streetKeys[0];
+    const matchedType = matchedStreetKey.split('|')[1] || parsed.streetType || '';
+    return {
+      id: 0,
+      province: range.province as string,
+      civic_number: parsed.civic || '',
+      street_name: parsed.streetName,
+      street_type: matchedType,
+      street_direction: parsed.streetDirection || '',
+      unit: '',
+      postal_code: parsed.postal || '',
+      city: parsed.city,
+      lat: range.lat as number,
+      lon: range.lon as number,
+      full_address: '',
+    };
   }
 
   return null;
@@ -317,32 +375,43 @@ async function findStreetInterpolated(
 async function findCityCentroid(
   env: Env,
   parsed: ReturnType<typeof parseAddressQuery>,
-  provinces: string[]
+  provinces: string[],
+  maxAmbiguousMatches: number
 ): Promise<{ lat: number; lon: number; province: string; city: string } | null> {
   if (!env.ODA_DB || !parsed.city) return null;
   const placeholders = provinces.map(() => '?').join(',');
 
   for (const prov of parsed.province ? [parsed.province] : provinces) {
     const cityKey = buildCityKey(parsed.city, prov);
-    const result = await env.ODA_DB.prepare(`
+    const result = await odaQueryFirst(
+      env,
+      `
       SELECT province, city, lat, lon FROM oda_city_centroids
       WHERE province = ? AND city_key = ?
       LIMIT 1
-    `)
-      .bind(prov, cityKey)
-      .first();
+    `,
+      [prov, cityKey]
+    );
     if (result) return result as { lat: number; lon: number; province: string; city: string };
   }
 
-  const result = await env.ODA_DB.prepare(`
+  const matches = await odaQueryAll(
+    env,
+    `
     SELECT province, city, lat, lon FROM oda_city_centroids
     WHERE province IN (${placeholders}) AND city_key LIKE ?
-    LIMIT ${provinces.length}
-  `)
-    .bind(...provinces, `${normalizeSearchToken(parsed.city)}|%`)
-    .all();
+    LIMIT ${maxAmbiguousMatches + 1}
+  `,
+    [...provinces, `${normalizeSearchToken(parsed.city)}|%`]
+  );
 
-  const matches = result.results || [];
+  if (matches.length > maxAmbiguousMatches) {
+    throw new OdaGeocodeError(
+      'Too many city matches found; provide province to disambiguate',
+      'AMBIGUOUS_LOCATION',
+      422
+    );
+  }
   if (matches.length > 1) {
     throw new OdaGeocodeError(
       'Multiple city matches found; provide province to disambiguate',
@@ -394,8 +463,8 @@ async function findNearestNeighbor(
     query += ` LIMIT ?`;
     params.push(config.nnMaxCandidates);
 
-    const results = await env.ODA_DB.prepare(query).bind(...params).all();
-    candidates = (results.results || []) as unknown as OdaAddressRow[];
+    const results = await odaQueryAll(env, query, params);
+    candidates = results as unknown as OdaAddressRow[];
     if (candidates.length >= 1) break;
   }
 
@@ -411,12 +480,35 @@ async function findNearestNeighbor(
   return best;
 }
 
+function postalCentroidWithinHintDistance(
+  centroid: { lat: number; lon: number },
+  qp: QueryParams,
+  maxDistanceMeters: number
+): boolean {
+  if (qp.lat === undefined || qp.lon === undefined) return true;
+  const distance = haversineMeters(qp.lon, qp.lat, centroid.lon, centroid.lat);
+  return distance <= maxDistanceMeters;
+}
+
 export async function geocodeWithOda(env: Env, qp: QueryParams): Promise<OdaGeocodeResult> {
   const config = getOdaConfig(env);
   if (!env.ODA_DB) {
     throw new OdaGeocodeError('ODA database not configured', 'ODA_NOT_CONFIGURED', 503);
   }
 
+  beginOdaD1QueryTracking();
+  try {
+    return await geocodeWithOdaInner(env, qp, config);
+  } finally {
+    endOdaD1QueryTracking();
+  }
+}
+
+async function geocodeWithOdaInner(
+  env: Env,
+  qp: QueryParams,
+  config: ReturnType<typeof getOdaConfig>
+): Promise<OdaGeocodeResult> {
   const parsed = parseAddressQuery({
     address: qp.address ? expandStreetAddress(qp.address) : undefined,
     postal: qp.postal,
@@ -466,7 +558,10 @@ export async function geocodeWithOda(env: Env, qp: QueryParams): Promise<OdaGeoc
     const postal = normalizePostalCode(parsed.postal);
     if (postal) {
       const centroid = await findPostalCentroid(env, postal, provinces);
-      if (centroid) {
+      if (
+        centroid &&
+        postalCentroidWithinHintDistance(centroid, qp, config.maxPostalCentroidDistanceMeters)
+      ) {
         return assertConfidence(
           buildResult(
             {
@@ -492,7 +587,7 @@ export async function geocodeWithOda(env: Env, qp: QueryParams): Promise<OdaGeoc
   }
 
   if (parsed.city) {
-    const cityCentroid = await findCityCentroid(env, parsed, provinces);
+    const cityCentroid = await findCityCentroid(env, parsed, provinces, config.maxAmbiguousMatches);
     if (cityCentroid) {
       const result = buildResult(
         {

--- a/src/oda-normalize.ts
+++ b/src/oda-normalize.ts
@@ -273,6 +273,12 @@ export function parseFreeformAddress(address: string): {
   let normalized = address.trim();
   let unit: string | undefined;
 
+  const unitCommaSuffixMatch = normalized.match(/^(.+?),\s*Unit\s+#?\s*(\S+)\s*$/i);
+  if (unitCommaSuffixMatch) {
+    normalized = unitCommaSuffixMatch[1].trim();
+    unit = unitCommaSuffixMatch[2].replace(/[,;]+$/, '');
+  }
+
   const unitSuffixMatch = normalized.match(/^(.+?)\s+UNIT\s+(\S+)\s*$/i);
   if (unitSuffixMatch) {
     normalized = unitSuffixMatch[1].trim();

--- a/src/types.ts
+++ b/src/types.ts
@@ -270,6 +270,7 @@ export interface LookupResult {
   riding?: string;
   normalizedAddress?: string;
   addressComponents?: GoogleAddressComponents;
+  mailingAddress?: CanadaPostStyleAddress;
 }
 
 // Lookup cache entry structure
@@ -279,6 +280,7 @@ export interface LookupCacheEntry {
   point?: { lon: number; lat: number };
   normalizedAddress?: string;
   addressComponents?: GoogleAddressComponents;
+  mailingAddress?: CanadaPostStyleAddress;
   timestamp: number;
   dataset: string;
 }
@@ -308,6 +310,8 @@ export interface BatchLookupResponse {
   municipality?: string;
   normalizedAddress?: string;
   addressComponents?: GoogleAddressComponents;
+  mailingAddress?: CanadaPostStyleAddress;
+  geocode?: { method: string; confidence?: number };
   error?: string;
   processingTime: number;
 }
@@ -429,6 +433,9 @@ export interface Metrics {
   geocodingOdaTime: number;
   geocodingGeoGratisTime: number;
   geocodingFallbackTime: number;
+  odaD1Reads: number;
+  odaD1QueriesMaxPerRequest: number;
+  odaStageTimeouts: number;
   totalR2Time: number;
   totalBatchTime: number;
   totalWebhookTime: number;

--- a/src/types.ts
+++ b/src/types.ts
@@ -27,6 +27,7 @@ export interface Env {
   ODA_NN_MAX_CANDIDATES?: string;
   ODA_MAX_REVERSE_DISTANCE_METERS?: string;
   ODA_MAX_AMBIGUOUS_MATCHES?: string;
+  ODA_MAX_POSTAL_CENTROID_DISTANCE_METERS?: string;
 }
 
 // ODA geocoding types

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -382,8 +382,9 @@ export default {
 
         const metrics = getMetrics();
         const circuitBreakerStates = {
-          geocoding: await geocodingCircuitBreaker.getStateInfo('geocoding:nominatim'),
-          r2: await r2CircuitBreaker.getStateInfo('r2:federalridings-2024.geojson')
+          geocodingOda: await geocodingCircuitBreaker.getStateInfo('geocoding:oda'),
+          geocodingNominatim: await geocodingCircuitBreaker.getStateInfo('geocoding:nominatim'),
+          r2: await r2CircuitBreaker.getStateInfo('r2:federalridings-2024.geojson'),
         };
         const datasets = await checkRidingDatasets(env);
         const datasetsOk = allRequiredDatasetsPresent(datasets);
@@ -402,6 +403,36 @@ export default {
             "content-type": "application/json; charset=UTF-8",
             'Access-Control-Allow-Origin': '*'
           }
+        });
+      }
+
+      // Admin circuit breaker reset
+      if (pathname === '/admin/circuit-breaker/reset' && request.method === 'POST') {
+        if (!checkAdminAuth(request, env)) {
+          return unauthorizedResponse(correlationId);
+        }
+
+        const key = url.searchParams.get('key');
+        if (key) {
+          if (key.startsWith('r2:')) {
+            await r2CircuitBreaker.reset(key);
+          } else {
+            await geocodingCircuitBreaker.reset(key);
+          }
+          return new Response(JSON.stringify({ success: true, message: `Circuit breaker ${key} reset` }), {
+            headers: {
+              'content-type': 'application/json; charset=UTF-8',
+              'Access-Control-Allow-Origin': '*',
+            },
+          });
+        }
+
+        await geocodingCircuitBreaker.resetAll();
+        return new Response(JSON.stringify({ success: true, message: 'All circuit breakers reset' }), {
+          headers: {
+            'content-type': 'application/json; charset=UTF-8',
+            'Access-Control-Allow-Origin': '*',
+          },
         });
       }
 

--- a/test/helpers/oda-memory-db.ts
+++ b/test/helpers/oda-memory-db.ts
@@ -154,6 +154,9 @@ function sqlKind(sql: string): string {
   const s = sql.replace(/\s+/g, ' ').toUpperCase();
   if (s.includes('SEARCH_KEY =') && s.includes('ODA_ADDRESSES')) return 'exact';
   if (s.includes('ODA_POSTAL_CENTROIDS')) return 'postal';
+  if (s.includes('STREET_KEY IN') && s.includes('CIVIC_NUMBER =')) return 'street_in_exact';
+  if (s.includes('STREET_KEY IN') && s.includes('ORDER BY ABS(CAST(CIVIC_NUMBER')) return 'street_in_nearest';
+  if (s.includes('STREET_KEY IN') && s.includes('ODA_STREET_RANGES')) return 'street_in_range';
   if (s.includes('CIVIC_NUMBER =')) return 'street_exact';
   if (s.includes('ORDER BY ABS(CAST(CIVIC_NUMBER')) return 'street_nearest';
   if (s.includes('ODA_STREET_RANGES')) return 'street_range';
@@ -161,6 +164,43 @@ function sqlKind(sql: string): string {
   if (s.includes('ODA_CITY_CENTROIDS')) return 'city';
   if (s.includes('BETWEEN') && s.includes('ODA_ADDRESSES')) return 'bbox';
   return 'unknown';
+}
+
+function countPlaceholders(fragment: string | undefined): number {
+  if (!fragment) return 0;
+  return (fragment.match(/\?/g) || []).length;
+}
+
+function parseStreetInParams(sql: string, params: unknown[]): {
+  provinces: string[];
+  cityKey: string;
+  streetKeys: string[];
+  rest: unknown[];
+} {
+  const s = sql.replace(/\s+/g, ' ').toUpperCase();
+  const provinceIn = s.match(/PROVINCE IN \(([^)]+)\)/)?.[1];
+  const streetIn = s.match(/STREET_KEY IN \(([^)]+)\)/)?.[1];
+  const provinceCount = countPlaceholders(provinceIn);
+  const streetKeyCount = countPlaceholders(streetIn);
+  const provinces = params.slice(0, provinceCount).map(String);
+  const cityKey = String(params[provinceCount]);
+  const streetKeys = params.slice(provinceCount + 1, provinceCount + 1 + streetKeyCount).map(String);
+  const rest = params.slice(provinceCount + 1 + streetKeyCount);
+  return { provinces, cityKey, streetKeys, rest };
+}
+
+function pickStreetMatch<T extends { street_key: string }>(
+  rows: T[],
+  streetKeys: string[],
+  orderParams: string[]
+): T | null {
+  if (rows.length === 0) return null;
+  const rank = new Map(orderParams.map((key, index) => [key, index]));
+  return [...rows].sort((a, b) => {
+    const aRank = rank.get(a.street_key) ?? streetKeys.length;
+    const bRank = rank.get(b.street_key) ?? streetKeys.length;
+    return aRank - bRank;
+  })[0];
 }
 
 function executeQuery(db: OdaMemoryDb, sql: string, params: unknown[]): unknown {
@@ -196,6 +236,57 @@ function executeQuery(db: OdaMemoryDb, sql: string, params: unknown[]): unknown 
         if (hit) return hit;
       }
       return null;
+    }
+    case 'street_in_exact': {
+      const { provinces, cityKey, streetKeys, rest } = parseStreetInParams(sql, params);
+      const hasUnit = sql.toUpperCase().includes('AND UNIT =');
+      const civic = String(rest[0]);
+      const unitFilter = hasUnit ? String(rest[1]) : undefined;
+      const orderParams = hasUnit ? rest.slice(2).map(String) : rest.slice(1).map(String);
+      const candidates = db.addresses.filter(
+        (a) =>
+          provinces.includes(a.province) &&
+          a.city_key === cityKey &&
+          streetKeys.includes(a.street_key) &&
+          a.civic_number === civic &&
+          (!unitFilter || a.unit === unitFilter)
+      );
+      return pickStreetMatch(candidates, streetKeys, orderParams) ?? null;
+    }
+    case 'street_in_nearest': {
+      const { provinces, cityKey, streetKeys, rest } = parseStreetInParams(sql, params);
+      const orderParams = rest.slice(0, -1).map(String);
+      const civicNumeric = Number(rest[rest.length - 1]);
+      const candidates = db.addresses.filter(
+        (a) =>
+          provinces.includes(a.province) &&
+          a.city_key === cityKey &&
+          streetKeys.includes(a.street_key)
+      );
+      if (candidates.length === 0) return null;
+      const bestStreet = pickStreetMatch(candidates, streetKeys, orderParams);
+      const sameStreet = candidates.filter((a) => a.street_key === bestStreet?.street_key);
+      return sameStreet.reduce((best, row) => {
+        const bestNum = parseInt(best.civic_number, 10);
+        const rowNum = parseInt(row.civic_number, 10);
+        const bestDist = Math.abs(bestNum - civicNumeric);
+        const rowDist = Math.abs(rowNum - civicNumeric);
+        return rowDist < bestDist ? row : best;
+      });
+    }
+    case 'street_in_range': {
+      const { provinces, cityKey, streetKeys, rest } = parseStreetInParams(sql, params);
+      const orderParams = rest.map(String);
+      const hits = streetKeys
+        .map((streetKey) => {
+          for (const prov of provinces) {
+            const hit = db.streetRanges.get(`${prov}|${cityKey}|${streetKey}`);
+            if (hit) return { ...hit, street_key: streetKey };
+          }
+          return null;
+        })
+        .filter(Boolean) as Array<{ province: string; lat: number; lon: number; street_key: string }>;
+      return pickStreetMatch(hits, streetKeys, orderParams);
     }
     case 'street_exact': {
       const hasUnitFilter = sql.toUpperCase().includes('AND UNIT =');

--- a/test/lookup-expansion.test.ts
+++ b/test/lookup-expansion.test.ts
@@ -111,25 +111,53 @@ describe('buildExpandedLookupPayload', () => {
     expect(payload.province_data).toBeUndefined();
   });
 
-  it('does not include normalizedAddress unless requested via return selector', () => {
+  it('includes normalized address fields when present on base or address context', () => {
     const payload = buildExpandedLookupPayload(
       {
         properties: { FED_NUM: '35075' },
         riding: 'Toronto Centre',
-        normalizedAddress: '123 Main St, Toronto, ON',
-        addressComponents: { locality: 'Toronto' },
+        normalizedAddress: '123 MAIN ST, TORONTO ON, CANADA',
+        addressComponents: { locality: 'TORONTO' },
       },
       [],
       '/api/federal',
       {
         addressContext: {
-          normalizedAddress: '456 Other St, Toronto, ON',
-          addressComponents: { locality: 'Toronto' },
+          normalizedAddress: '456 OTHER ST, TORONTO ON, CANADA',
+          addressComponents: { locality: 'TORONTO' },
+          mailingAddress: {
+            line1: '456 OTHER ST',
+            municipality: 'TORONTO',
+            province: 'ON',
+            country: 'CANADA',
+            formattedSingleLine: '456 OTHER ST, TORONTO ON, CANADA',
+            formattedMultiline: '456 OTHER ST\nTORONTO ON\nCANADA',
+            canadaPostCertified: false,
+          },
+          geocodeMethod: 'exact',
+          geocodeConfidence: 1,
         },
       }
     );
 
-    expect(payload.normalizedAddress).toBeUndefined();
-    expect(payload.addressComponents).toBeUndefined();
+    expect(payload.normalizedAddress).toBe('456 OTHER ST, TORONTO ON, CANADA');
+    expect(payload.addressComponents?.locality).toBe('TORONTO');
+    expect(payload.mailingAddress?.line1).toBe('456 OTHER ST');
+    expect(payload.geocode?.method).toBe('exact');
+  });
+
+  it('falls back to base normalized address when address context has none', () => {
+    const payload = buildExpandedLookupPayload(
+      {
+        properties: { FED_NUM: '35075' },
+        riding: 'Toronto Centre',
+        normalizedAddress: '123 MAIN ST, TORONTO ON, CANADA',
+      },
+      [],
+      '/api/federal',
+      { addressContext: {} }
+    );
+
+    expect(payload.normalizedAddress).toBe('123 MAIN ST, TORONTO ON, CANADA');
   });
 });

--- a/test/oda-batch.test.ts
+++ b/test/oda-batch.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import { geocodeBatchWithOda } from '../src/oda-geocoding';
+import { createOdaFixtureEnv } from './helpers/oda-memory-db';
+import { SUPPORTED_ODA_PROVINCES } from '../src/oda-import';
+import type { Env } from '../src/types';
+
+const { d1: fixtureD1 } = createOdaFixtureEnv();
+
+function odaEnv(): Env {
+  return {
+    RIDINGS: {} as R2Bucket,
+    ODA_DB: fixtureD1,
+    ODA_GEOCODING_ENABLED: 'true',
+    ODA_PROVINCES: SUPPORTED_ODA_PROVINCES.join(','),
+    ODA_MIN_CONFIDENCE: '0.6',
+  };
+}
+
+describe('geocodeBatchWithOda', () => {
+  it('geocodes multiple addresses including unit and Victoria Park', async () => {
+    const results = await geocodeBatchWithOda(odaEnv(), [
+      { address: '123 Main St', city: 'Toronto', state: 'ON' },
+      { address: 'Unit 1205, 123 Main St', city: 'Toronto', state: 'ON' },
+      { address: '757 Victoria Park', city: 'Toronto', state: 'ON' },
+      { postal: 'M5V2T6', state: 'ON' },
+    ]);
+
+    expect(results).toHaveLength(4);
+    expect(results[0].success).toBe(true);
+    expect(results[0].geocodeMethod).toBe('exact');
+    expect(results[1].success).toBe(true);
+    expect(results[1].geocodeMethod).toBe('exact');
+    expect(results[2].success).toBe(true);
+    expect(results[3].success).toBe(true);
+    expect(results[3].geocodeMethod).toBe('postal_centroid');
+  });
+
+  it('returns failures for missing addresses without tripping circuit breaker', async () => {
+    const results = await geocodeBatchWithOda(odaEnv(), [
+      { address: '999 Nonexistent Blvd', city: 'Toronto', state: 'ON' },
+    ]);
+    expect(results[0].success).toBe(false);
+    expect(results[0].error).toContain('not found');
+  });
+});

--- a/test/oda-comparison-cases.test.ts
+++ b/test/oda-comparison-cases.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+import { geocodeIfNeeded } from '../src/geocoding';
+import { createCircuitBreaker } from '../src/circuit-breaker';
+import { createOdaFixtureEnv } from './helpers/oda-memory-db';
+import { SUPPORTED_ODA_PROVINCES } from '../src/oda-import';
+import type { Env, QueryParams } from '../src/types';
+
+type ComparisonCase = {
+  id: string;
+  category: string;
+  label: string;
+  query: QueryParams & { province?: string };
+};
+
+const casesPath = join(process.cwd(), 'test/fixtures/comparison/opennorth-cases.json');
+const allCases = JSON.parse(readFileSync(casesPath, 'utf-8')) as ComparisonCase[];
+const addressCases = allCases.filter((c) => c.category === 'B' || c.category === 'G');
+
+const { d1: fixtureD1 } = createOdaFixtureEnv();
+
+function odaEnv(): Env {
+  return {
+    RIDINGS: {} as R2Bucket,
+    ODA_DB: fixtureD1,
+    ODA_GEOCODING_ENABLED: 'true',
+    ODA_PROVINCES: SUPPORTED_ODA_PROVINCES.join(','),
+    ODA_MIN_CONFIDENCE: '0.6',
+    GEOCODING_CACHE: {
+      get: async () => null,
+      put: async () => {},
+      delete: async () => {},
+      list: async () => ({ keys: [], list_complete: true, cacheStatus: null }),
+      getWithMetadata: async () => ({ value: null, metadata: null, cacheStatus: null }),
+    } as KVNamespace,
+  };
+}
+
+const circuitBreaker = createCircuitBreaker(3, 30000, 2);
+
+describe('ODA comparison address cases (offline, categories B and G)', () => {
+  const originalFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    globalThis.fetch = vi.fn(async (url: string | URL) => {
+      if (String(url).includes('geolocator.api.geo.ca') || String(url).includes('geogratis')) {
+        return new Response(
+          JSON.stringify([
+            {
+              geometry: { type: 'Point', coordinates: [-79.38, 43.65] },
+              qualifier: 'GEOMETRIC_CENTER',
+              score: 0.9,
+            },
+          ]),
+          { status: 200, headers: { 'Content-Type': 'application/json' } }
+        );
+      }
+      throw new Error(`Unexpected fetch: ${String(url)}`);
+    }) as typeof fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  for (const testCase of addressCases) {
+    it(`${testCase.id}: ${testCase.label}`, async () => {
+      const qp: QueryParams = {
+        address: testCase.query.address,
+        postal: testCase.query.postal,
+        city: testCase.query.city,
+        state: testCase.query.province ?? testCase.query.state,
+      };
+
+      if (!qp.address && !qp.postal) {
+        return;
+      }
+
+      try {
+        await geocodeIfNeeded(odaEnv(), qp, undefined, undefined, {
+          execute: (key, fn, options) => circuitBreaker.execute(key, fn, options),
+        });
+      } catch (error) {
+        if (error instanceof Error && error.message.includes('Circuit breaker is OPEN')) {
+          throw error;
+        }
+      }
+    });
+  }
+});

--- a/test/oda-d1-tracker.test.ts
+++ b/test/oda-d1-tracker.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest';
+import { geocodeWithOda } from '../src/oda-geocoding';
+import { getMetrics, resetMetrics } from '../src/metrics';
+import { createOdaFixtureEnv } from './helpers/oda-memory-db';
+import { SUPPORTED_ODA_PROVINCES } from '../src/oda-import';
+import type { Env } from '../src/types';
+
+const { d1: fixtureD1 } = createOdaFixtureEnv();
+
+function odaEnv(): Env {
+  return {
+    RIDINGS: {} as R2Bucket,
+    ODA_DB: fixtureD1,
+    ODA_GEOCODING_ENABLED: 'true',
+    ODA_PROVINCES: SUPPORTED_ODA_PROVINCES.join(','),
+    ODA_MIN_CONFIDENCE: '0.6',
+  };
+}
+
+describe('ODA D1 query budget', () => {
+  it('uses at most 3 D1 reads for street interpolation without type', async () => {
+    resetMetrics();
+    await geocodeWithOda(odaEnv(), { address: '757 Victoria Park', city: 'Toronto', state: 'ON' });
+    const metrics = getMetrics();
+    expect(metrics.odaD1QueriesMaxPerRequest).toBeLessThanOrEqual(3);
+  });
+
+  it('uses 1 D1 read for exact match', async () => {
+    resetMetrics();
+    await geocodeWithOda(odaEnv(), { address: '123 Main St', city: 'Toronto', state: 'ON' });
+    const metrics = getMetrics();
+    expect(metrics.odaD1QueriesMaxPerRequest).toBe(1);
+  });
+});

--- a/test/oda-geocoding-live.test.ts
+++ b/test/oda-geocoding-live.test.ts
@@ -78,6 +78,31 @@ const LIVE_CASES: LiveCase[] = [
     expectStatus: 422,
     expectCode: 'AMBIGUOUS_LOCATION',
   },
+  {
+    name: '901-560 Birchmount Rd Toronto',
+    path: `/api/geocode?${queryString({ address: '901-560 Birchmount Rd', city: 'Toronto', state: 'ON' })}`,
+    expectStatus: 200,
+  },
+  {
+    name: 'Unit 1205, 123 Main St Toronto',
+    path: `/api/geocode?${queryString({ address: 'Unit 1205, 123 Main St', city: 'Toronto', state: 'ON' })}`,
+    expectStatus: 200,
+    expectMethod: 'exact',
+    latClose: 43.6533,
+    lonClose: -79.3833,
+  },
+  {
+    name: '757 Victoria Park Ave street beats postal',
+    path: `/api/geocode?${queryString({
+      address: '757 Victoria Park Ave',
+      postal: 'M5V2T6',
+      city: 'Toronto',
+      state: 'ON',
+    })}`,
+    expectStatus: 200,
+    latClose: 43.692101,
+    lonClose: -79.288688,
+  },
 ];
 
 describe.skipIf(!runLive)('ODA live geocoding (ODA_LIVE=1)', () => {

--- a/test/oda-normalize.test.ts
+++ b/test/oda-normalize.test.ts
@@ -52,6 +52,21 @@ describe('oda-normalize', () => {
     expect(parsed.streetType).toBe('AVE');
   });
 
+  it('parses comma unit suffix with hash', () => {
+    const parsed = parseFreeformAddress('90 Edgewood Ave, Unit # 132');
+    expect(parsed.unit).toBe('132');
+    expect(parsed.civic).toBe('90');
+    expect(parsed.streetName).toBe('Edgewood');
+    expect(parsed.streetType).toBe('AVE');
+  });
+
+  it('parses 312 Unit 4 Dundas St E', () => {
+    const parsed = parseFreeformAddress('312 Unit 4 Dundas St E');
+    expect(parsed.unit).toBe('4');
+    expect(parsed.civic).toBe('312');
+    expect(parsed.streetDirection).toBe('E');
+  });
+
   it('includes unit in parseAddressQuery', () => {
     const parsed = parseAddressQuery({
       address: '901-560 Birchmount Rd',


### PR DESCRIPTION
## Summary

Lookup and batch endpoints now return richer address data from ODA geocoding, and the ODA pipeline is more observable and resilient.

- Add `mailingAddress` (Canada Post–style) and `geocode` (`method`, `confidence`) to single and batch lookup responses
- Propagate address fields through geocoding, lookup expansion, and cache read/write paths
- Extend batch geocoding results with `mailingAddress`, `geocodeMethod`, and `confidence`
- Improve ODA street interpolation with street-type variant matching and configurable postal-centroid distance
- Track ODA D1 query counts per request and expose them in metrics
- Split geocoding circuit-breaker health (ODA vs Nominatim) and add an admin reset endpoint

## Issues touched

- [#8 — speed bottleneck compared to opennorth](https://github.com/chester-hill-solutions/riding-and-address/issues/8) — ODA D1 query tracking/metrics, circuit-breaker observability and reset
- [#10 — Test Cases (base line meet opennorth)](https://github.com/chester-hill-solutions/riding-and-address/issues/10) — offline ODA geocode tests against OpenNorth comparison fixture (categories B/G)
- [#11 — Advanced Test Cases (beat opennorth)](https://github.com/chester-hill-solutions/riding-and-address/issues/11) — street-type variant matching, unit parsing, and comparison-case coverage
- [#16 — NAR: normalize CSV rows and extract mailing fields](https://github.com/chester-hill-solutions/riding-and-address/issues/16) — return Canada Post–style `mailingAddress` in lookup/batch responses (response surface only; NAR ingest still open)
- [#17 — NAR: local fixture import into D1 with geocode acceptance tests](https://github.com/chester-hill-solutions/riding-and-address/issues/17) — expanded in-memory D1 test helper and geocode acceptance tests (ODA fixture path)

## Test plan

- [x] `npm run typecheck`
- [x] `npm test` (378 passed)
- [x] CI `validate` check green
- [ ] Spot-check a single lookup with `return=` fields including address data
- [ ] Spot-check a batch request and confirm `mailingAddress` / `geocode` appear in results